### PR TITLE
Use qualifiers when setting up cf deployer beans

### DIFF
--- a/ci/scripts/manage-bosh-bbl-environment.sh
+++ b/ci/scripts/manage-bosh-bbl-environment.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euox pipefail
+set -euo pipefail
 readonly SCRIPT_DIR=$(readlink -m $(dirname $0))
 readonly CI_DIR=$(dirname "${SCRIPT_DIR}")
 readonly BBL_VERSION=v6.9.16


### PR DESCRIPTION
This allows consuming libraries to provide beans of the same type without conflict