### PR TITLE
Add dir and modify build task for reference docs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -282,13 +282,16 @@ configure(rootProject) {
 		destinationDir = new File(buildDir, "api")
 	}
 
-	task docsZip(type: Zip) {
+	task docsZip(type: Zip, dependsOn: [':spring-cloud-app-broker-docs:asciidoctor']) {
 		group = "Distribution"
 		classifier = "docs"
 		description = "Builds -${classifier} archive containing api and reference " +
 				"for deployment."
 
 		from (api) { into "api" }
+		from(project.tasks.findByPath(':spring-cloud-app-broker-docs:asciidoctor')) {
+			into 'reference'
+		}
 	}
 
 	task distZip(type: Zip, dependsOn: docsZip) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ rootProject.name = "spring-cloud-app-broker"
 
 include "spring-cloud-app-broker-deployer"
 include "spring-cloud-app-broker-deployer-cloudfoundry"
+include "spring-cloud-app-broker-docs"
 include "spring-cloud-app-broker-core"
 include "spring-cloud-app-broker-autoconfigure"
 include "spring-cloud-app-broker-integration-tests"

--- a/spring-cloud-app-broker-docs/build.gradle
+++ b/spring-cloud-app-broker-docs/build.gradle
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+	id 'org.asciidoctor.convert'
+}
+
+description = "Spring Cloud App Broker Documentation"
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.boot:spring-boot-dependencies:${springBootVersion}"
+	}
+}
+
+apply plugin: 'org.asciidoctor.convert'
+
+dependencies {
+	implementation project(":spring-cloud-app-broker-core")
+	implementation("org.springframework.boot:spring-boot-starter")
+	implementation("org.springframework.boot:spring-boot-starter-security")
+	implementation("org.springframework.boot:spring-boot-starter-tomcat")
+	implementation("io.projectreactor:reactor-core")
+}
+
+asciidoctor {
+
+	attributes 'revnumber': project.version,
+			'branch-or-tag': project.version.endsWith('SNAPSHOT') ? 'master' : "v${project.version}",
+			'nofooter': true,
+			'allow-uri-read': ''
+}

--- a/spring-cloud-app-broker-docs/src/docs/asciidoc/index.adoc
+++ b/spring-cloud-app-broker-docs/src/docs/asciidoc/index.adoc
@@ -1,0 +1,24 @@
+= Spring Cloud App Broker
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+:sectlinks:
+
+:sapbr: https://cloud.spring.io/spring-cloud-app-broker/
+:sapbr-href: {sapbr}[Spring Cloud App Broker]
+:sapbr-api: https://docs.spring.io/spring-cloud-app-broker/docs/current/apidocs/
+:source: {github}/tree/{branch-or-tag}
+:scosb: https://cloud.spring.io/spring-cloud-open-service-broker/
+:scosb-href: {scosb}[Spring Cloud Open Service Broker]
+:osbapi: https://www.openservicebrokerapi.org/
+:osbapi-href: {osbapi}[Open Service Broker API]
+:springboot: https://projects.spring.io/spring-boot/
+:springboot-href: {springboot}[Spring Boot]
+:springboot-docs: https://projects.spring.io/spring-boot/
+:springboot-api: https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/
+
+[[abstract]]
+
+Spring Cloud Open Service Broker is a framework for building {springboot-href} applications that implement the {osbapi-href} and deploy applications to back service instances.


### PR DESCRIPTION
`./gradlew docs` builds documentation in `spring-cloud-app-broker-docs/build/`.