### PR TITLE
Deep copying BackingApplication values

### DIFF
--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/BackingApplication.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/BackingApplication.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class BackingApplication {
 
@@ -46,13 +47,13 @@ public class BackingApplication {
 			: new HashMap<>(backingApplicationToCopy.environment);
 		this.services = backingApplicationToCopy.services == null
 			? new ArrayList<>()
-			: new ArrayList<>(backingApplicationToCopy.services);
+			: backingApplicationToCopy.services.stream().map(ServicesSpec::new).collect(Collectors.toList());
 		this.parametersTransformers = backingApplicationToCopy.parametersTransformers == null
 			? new ArrayList<>()
-			: new ArrayList<>(backingApplicationToCopy.parametersTransformers);
+			: backingApplicationToCopy.parametersTransformers.stream().map(ParametersTransformerSpec::new).collect(Collectors.toList());
 		this.credentialProviders = backingApplicationToCopy.credentialProviders == null
 			? new ArrayList<>()
-			: new ArrayList<>(backingApplicationToCopy.credentialProviders);
+			: backingApplicationToCopy.credentialProviders.stream().map(CredentialProviderSpec::new).collect(Collectors.toList());
 	}
 
 	private BackingApplication() {
@@ -136,6 +137,7 @@ public class BackingApplication {
 	public void setCredentialProviders(List<CredentialProviderSpec> credentialProviders) {
 		this.credentialProviders = credentialProviders;
 	}
+
 	public static BackingApplicationBuilder builder() {
 		return new BackingApplicationBuilder();
 	}

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/CredentialProviderSpec.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/CredentialProviderSpec.java
@@ -20,6 +20,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class CredentialProviderSpec {
+
 	private String name;
 	private Map<String, Object> args;
 
@@ -29,6 +30,11 @@ public class CredentialProviderSpec {
 	CredentialProviderSpec(String name, Map<String, Object> args) {
 		this.name = name;
 		this.args = args;
+	}
+
+	CredentialProviderSpec(CredentialProviderSpec credentialProviderSpecToClone) {
+		this.name = credentialProviderSpecToClone.name;
+		this.args = credentialProviderSpecToClone.args;
 	}
 
 	public String getName() {
@@ -52,6 +58,7 @@ public class CredentialProviderSpec {
 	}
 
 	public static class CredentialProviderSpecBuilder {
+
 		private String name;
 		private final Map<String, Object> args = new LinkedHashMap<>();
 

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/ParametersTransformerSpec.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/ParametersTransformerSpec.java
@@ -31,6 +31,11 @@ public class ParametersTransformerSpec {
 		this.args = args;
 	}
 
+	ParametersTransformerSpec(ParametersTransformerSpec parametersTransformerSpecToClone) {
+		this.name = parametersTransformerSpecToClone.name;
+		this.args = parametersTransformerSpecToClone.args;
+	}
+
 	public String getName() {
 		return name;
 	}

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/ServicesSpec.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/ServicesSpec.java
@@ -23,6 +23,10 @@ public class ServicesSpec {
 	private ServicesSpec() {
 	}
 
+	ServicesSpec(ServicesSpec servicesSpecToClone) {
+		this.serviceInstanceName = servicesSpecToClone.serviceInstanceName;
+	}
+
 	ServicesSpec(String serviceInstanceName) {
 		this.serviceInstanceName = serviceInstanceName;
 	}

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/TargetSpec.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/TargetSpec.java
@@ -27,6 +27,10 @@ public class TargetSpec {
 		this.name = name;
 	}
 
+	TargetSpec(TargetSpec targetSpecToClone) {
+		this.name = targetSpecToClone.name;
+	}
+
 	public String getName() {
 		return name;
 	}


### PR DESCRIPTION
In order to avoid double mutation of the fields on BackingApplication the copy constructor was fixed to deep copy each collection instead of passing the references through
Added a second service instance creation to a component test

[Fixes #205]