### PR TITLE
Add support to manage backing apps via a service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,10 +42,10 @@ configure(allprojects) {
 	apply plugin: "maven-publish"
 
 	ext {
-		springBootVersion = project.findProperty("springBootVersion") ?: "2.1.1.RELEASE"
-		springVersion = project.findProperty("springVersion") ?: "5.1.3.RELEASE"
-		reactorVersion = project.findProperty("reactorVersion") ?: "Californium-SR3"
-		openServiceBrokerVersion = "3.0.0.M4"
+		springBootVersion = project.findProperty("springBootVersion") ?: "2.1.3.RELEASE"
+		springVersion = project.findProperty("springVersion") ?: "5.1.5.RELEASE"
+		reactorVersion = project.findProperty("reactorVersion") ?: "Californium-SR5"
+		openServiceBrokerVersion = "3.0.0.BUILD-SNAPSHOT"
 		springCredhubVersion = "2.0.0.BUILD-SNAPSHOT"
 		cfJavaClientVersion = "3.15.0.RELEASE"
 		mockitoVersion = "2.23.4"

--- a/spring-cloud-app-broker-acceptance-tests/README.adoc
+++ b/spring-cloud-app-broker-acceptance-tests/README.adoc
@@ -12,6 +12,7 @@ The tests require the following properties to be set:
 
 * `spring.cloud.appbroker.acceptance-test.cloudfoundry.api-host` - The CF API host where the tests are going to run.
 * `spring.cloud.appbroker.acceptance-test.cloudfoundry.api-port` - The CF API port where the tests are going to run.
+* `spring.cloud.appbroker.acceptance-test.cloudfoundry.apps-domain` - The CF apps domain where the tests are going to run.
 * `spring.cloud.appbroker.acceptance-test.cloudfoundry.default-org` - The CF organization where the tests are going to run.
 * `spring.cloud.appbroker.acceptance-test.cloudfoundry.default-space` - The CF space where the tests are going to run.
 * `spring.cloud.appbroker.acceptance-test.cloudfoundry.skip-ssl-validation` - If SSL validation should be skipped.

--- a/spring-cloud-app-broker-acceptance-tests/build.gradle
+++ b/spring-cloud-app-broker-acceptance-tests/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018. the original author or authors.
+ * Copyright 2016-2019. the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ dependencies {
 	testImplementation("com.revinate:assertj-json:1.2.0")
 
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
+	testCompile("io.projectreactor:reactor-test")
 }
 
 // build the test broker from /src into a jar that the tests can deploy

--- a/spring-cloud-app-broker-acceptance-tests/build.gradle
+++ b/spring-cloud-app-broker-acceptance-tests/build.gradle
@@ -35,15 +35,11 @@ apply plugin: 'org.springframework.boot'
 dependencies {
 	compile project(":spring-cloud-starter-app-broker-cloudfoundry")
 	compile("org.springframework.boot:spring-boot-starter-webflux")
-
 	testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
-
-	testImplementation("org.junit.jupiter:junit-jupiter-api")
-	testImplementation("org.assertj:assertj-core:${assertjVersion}")
-	testImplementation("com.revinate:assertj-json:1.2.0")
-
-	testImplementation("org.springframework.boot:spring-boot-starter-test")
+	testCompile("org.junit.jupiter:junit-jupiter-api")
+	testCompile("org.springframework.boot:spring-boot-starter-test")
 	testCompile("io.projectreactor:reactor-test")
+	testCompile("org.assertj:assertj-core")
 }
 
 // build the test broker from /src into a jar that the tests can deploy

--- a/spring-cloud-app-broker-acceptance-tests/src/main/java/org/springframework/cloud/appbroker/acceptance/ManagementController.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/main/java/org/springframework/cloud/appbroker/acceptance/ManagementController.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016-2019 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.acceptance;
+
+import reactor.core.publisher.Mono;
+
+import org.springframework.cloud.appbroker.manager.BackingAppManagementService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ManagementController {
+
+	private final BackingAppManagementService service;
+
+	public ManagementController(BackingAppManagementService service) {
+		this.service = service;
+	}
+
+	@GetMapping("/start/{serviceInstanceId}")
+	public Mono<String> startApplications(@PathVariable String serviceInstanceId) {
+		return service.start(serviceInstanceId)
+			.thenReturn("starting " + serviceInstanceId);
+	}
+
+	@GetMapping("/stop/{serviceInstanceId}")
+	public Mono<String> stopApplications(@PathVariable String serviceInstanceId) {
+		return service.stop(serviceInstanceId)
+			.thenReturn("stopping " + serviceInstanceId);
+	}
+
+	@GetMapping("/restart/{serviceInstanceId}")
+	public Mono<String> restartApplications(@PathVariable String serviceInstanceId) {
+		return service.restart(serviceInstanceId)
+			.thenReturn("restarting " + serviceInstanceId);
+	}
+
+	@GetMapping("/restage/{serviceInstanceId}")
+	public Mono<String> restageApplications(@PathVariable String serviceInstanceId) {
+		return service.restage(serviceInstanceId)
+			.thenReturn("restaging " + serviceInstanceId);
+	}
+}

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org.springframework.cloud.appbroker.acceptance/AppManagementAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org.springframework.cloud.appbroker.acceptance/AppManagementAcceptanceTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2016-2019 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.acceptance;
+
+import javax.net.ssl.SSLException;
+import java.net.URI;
+import java.util.Date;
+import java.util.List;
+
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import org.cloudfoundry.operations.applications.ApplicationDetail;
+import org.cloudfoundry.operations.services.ServiceInstance;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import reactor.netty.http.client.HttpClient;
+import reactor.test.StepVerifier;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AppManagementAcceptanceTest extends CloudFoundryAcceptanceTest {
+
+	private static final String APP_1 = "app-1";
+
+	private static final String APP_2 = "app-2";
+
+	private static final String SI_NAME = "si-managed";
+
+	private final WebClient webClient = getSslIgnoringWebClient();
+
+	@BeforeEach
+	void setUp() {
+		StepVerifier.create(cloudFoundryService.deleteServiceInstance(SI_NAME))
+			.verifyComplete();
+
+		StepVerifier.create(cloudFoundryService.createServiceInstance(PLAN_NAME, APP_SERVICE_NAME, SI_NAME, null))
+			.verifyComplete();
+
+		StepVerifier.create(cloudFoundryService.getServiceInstance(SI_NAME))
+			.assertNext(serviceInstance -> assertThat(serviceInstance.getStatus()).isEqualTo("succeeded"))
+			.verifyComplete();
+	}
+
+	@AfterEach
+	void cleanUp() {
+		StepVerifier.create(cloudFoundryService.deleteServiceInstance(SI_NAME))
+			.verifyComplete();
+
+		StepVerifier.create(getApplications())
+			.verifyError();
+	}
+
+	@Test
+	@AppBrokerTestProperties({
+		"spring.cloud.appbroker.services[0].service-name=" + APP_SERVICE_NAME,
+		"spring.cloud.appbroker.services[0].plan-name=" + PLAN_NAME,
+		"spring.cloud.appbroker.services[0].apps[0].name=" + APP_1,
+		"spring.cloud.appbroker.services[0].apps[0].path=" + BACKING_APP_PATH,
+		"spring.cloud.appbroker.services[0].apps[1].name=" + APP_2,
+		"spring.cloud.appbroker.services[0].apps[1].path=" + BACKING_APP_PATH
+	})
+	void stopApps() {
+		StepVerifier.create(manageApps("stop"))
+			.assertNext(result -> assertThat(result).contains("stopping"))
+			.verifyComplete();
+
+		StepVerifier.create(getApplications())
+			.assertNext(apps -> assertThat(apps).extracting("runningInstances").containsOnly(0))
+			.verifyComplete();
+	}
+
+	@Test
+	@AppBrokerTestProperties({
+		"spring.cloud.appbroker.services[0].service-name=" + APP_SERVICE_NAME,
+		"spring.cloud.appbroker.services[0].plan-name=" + PLAN_NAME,
+		"spring.cloud.appbroker.services[0].apps[0].name=" + APP_1,
+		"spring.cloud.appbroker.services[0].apps[0].path=" + BACKING_APP_PATH,
+		"spring.cloud.appbroker.services[0].apps[1].name=" + APP_2,
+		"spring.cloud.appbroker.services[0].apps[1].path=" + BACKING_APP_PATH
+	})
+	void startApps() {
+		StepVerifier.create(cloudFoundryService.stopApplication(APP_1)
+			.then(cloudFoundryService.stopApplication(APP_2)))
+			.verifyComplete();
+
+		StepVerifier.create(getApplications())
+			.assertNext(apps -> assertThat(apps).extracting("runningInstances").containsOnly(0))
+			.verifyComplete();
+
+		StepVerifier.create(manageApps("start"))
+			.assertNext(result -> assertThat(result).contains("starting"))
+			.verifyComplete();
+
+		StepVerifier.create(getApplications())
+			.assertNext(apps -> assertThat(apps).extracting("runningInstances").containsOnly(1))
+			.verifyComplete();
+	}
+
+	@Test
+	@AppBrokerTestProperties({
+		"spring.cloud.appbroker.services[0].service-name=" + APP_SERVICE_NAME,
+		"spring.cloud.appbroker.services[0].plan-name=" + PLAN_NAME,
+		"spring.cloud.appbroker.services[0].apps[0].name=" + APP_1,
+		"spring.cloud.appbroker.services[0].apps[0].path=" + BACKING_APP_PATH,
+		"spring.cloud.appbroker.services[0].apps[1].name=" + APP_2,
+		"spring.cloud.appbroker.services[0].apps[1].path=" + BACKING_APP_PATH
+	})
+	void restartApps() {
+		List<ApplicationDetail> apps = getApplications().block();
+		Date originallySince1 = apps.get(0).getInstanceDetails().get(0).getSince();
+		Date originallySince2 = apps.get(1).getInstanceDetails().get(0).getSince();
+
+		StepVerifier.create(manageApps("restart"))
+			.assertNext(result -> assertThat(result).contains("restarting"))
+			.verifyComplete();
+
+		List<ApplicationDetail> restagedApps = getApplications().block();
+		Date since1 = restagedApps.get(0).getInstanceDetails().get(0).getSince();
+		Date since2 = restagedApps.get(1).getInstanceDetails().get(0).getSince();
+		assertThat(restagedApps).extracting("runningInstances").containsOnly(1);
+		assertThat(since1).isAfter(originallySince1);
+		assertThat(since2).isAfter(originallySince2);
+	}
+
+	@Test
+	@AppBrokerTestProperties({
+		"spring.cloud.appbroker.services[0].service-name=" + APP_SERVICE_NAME,
+		"spring.cloud.appbroker.services[0].plan-name=" + PLAN_NAME,
+		"spring.cloud.appbroker.services[0].apps[0].name=" + APP_1,
+		"spring.cloud.appbroker.services[0].apps[0].path=" + BACKING_APP_PATH,
+		"spring.cloud.appbroker.services[0].apps[1].name=" + APP_2,
+		"spring.cloud.appbroker.services[0].apps[1].path=" + BACKING_APP_PATH
+	})
+	void restageApps() throws Exception {
+		List<ApplicationDetail> apps = getApplications().block();
+		Date originallySince1 = apps.get(0).getInstanceDetails().get(0).getSince();
+		Date originallySince2 = apps.get(1).getInstanceDetails().get(0).getSince();
+		assertThat(apps).extracting("runningInstances").containsOnly(1);
+
+		StepVerifier.create(manageApps("restage"))
+			.assertNext(result -> assertThat(result).contains("restaging"))
+			.verifyComplete();
+
+		List<ApplicationDetail> restagedApps = getApplications().block();
+		Date since1 = restagedApps.get(0).getInstanceDetails().get(0).getSince();
+		Date since2 = restagedApps.get(1).getInstanceDetails().get(0).getSince();
+		assertThat(restagedApps).extracting("runningInstances").containsOnly(1);
+		assertThat(since1).isAfter(originallySince1);
+		assertThat(since2).isAfter(originallySince2);
+	}
+
+	private Mono<List<ApplicationDetail>> getApplications() {
+		return Flux.merge(cloudFoundryService.getApplication(APP_1),
+			cloudFoundryService.getApplication(APP_2))
+			.parallel()
+			.runOn(Schedulers.parallel())
+			.sequential()
+			.collectList();
+	}
+
+	private Mono<String> manageApps(String operation) {
+		return cloudFoundryService.getServiceInstance(SI_NAME)
+			.map(ServiceInstance::getId)
+			.flatMap(serviceInstanceId -> cloudFoundryService.getApplicationRoute(TEST_BROKER_APP_NAME)
+				.flatMap(appRoute -> webClient.get()
+					.uri(URI.create(appRoute + "/" + operation +  "/" + serviceInstanceId))
+					.exchange()
+					.flatMap(clientResponse -> clientResponse.toEntity(String.class))
+					.map(HttpEntity::getBody)));
+	}
+
+	private WebClient getSslIgnoringWebClient() {
+		return WebClient.builder()
+			.clientConnector(new ReactorClientHttpConnector(HttpClient
+				.create()
+				.secure(t -> {
+					try {
+						t.sslContext(SslContextBuilder
+							.forClient()
+							.trustManager(InsecureTrustManagerFactory.INSTANCE)
+							.build());
+					}
+					catch (SSLException e) {
+						e.printStackTrace();
+					}
+				})))
+			.build();
+	}
+}

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org.springframework.cloud.appbroker.acceptance/CloudFoundryAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org.springframework.cloud.appbroker.acceptance/CloudFoundryAcceptanceTest.java
@@ -67,7 +67,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableConfigurationProperties(AcceptanceTestProperties.class)
 class CloudFoundryAcceptanceTest {
 
-	private static final String TEST_BROKER_APP_NAME = "test-broker-app";
+	static final String TEST_BROKER_APP_NAME = "test-broker-app";
 	private static final String SERVICE_BROKER_NAME = "test-broker";
 	
 	static final String APP_SERVICE_NAME = "app-service";
@@ -76,7 +76,7 @@ class CloudFoundryAcceptanceTest {
 	static final String BACKING_APP_PATH = "classpath:backing-app.jar";
 
 	@Autowired
-	private CloudFoundryService cloudFoundryService;
+	protected CloudFoundryService cloudFoundryService;
 
 	@Autowired
 	private UaaService uaaService;
@@ -201,7 +201,7 @@ class CloudFoundryAcceptanceTest {
 	}
 
 	Optional<ApplicationSummary> getApplicationSummary(String appName, String space) {
-		return cloudFoundryService.getApplicationSummary(appName, space).blockOptional();
+		return cloudFoundryService.getApplication(appName, space).blockOptional();
 	}
 
 	ApplicationEnvironments getApplicationEnvironment(String appName) {
@@ -210,6 +210,10 @@ class CloudFoundryAcceptanceTest {
 
 	ApplicationEnvironments getApplicationEnvironment(String appName, String space) {
 		return cloudFoundryService.getApplicationEnvironment(appName, space).block();
+	}
+
+	String getTestBrokerAppRoute() {
+		return cloudFoundryService.getApplicationRoute(TEST_BROKER_APP_NAME).block();
 	}
 
 	DocumentContext getSpringAppJson(String appName) {

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org.springframework.cloud.appbroker.acceptance/CreateInstanceAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org.springframework.cloud.appbroker.acceptance/CreateInstanceAcceptanceTest.java
@@ -22,7 +22,6 @@ import com.jayway.jsonpath.DocumentContext;
 import org.cloudfoundry.operations.applications.ApplicationSummary;
 import org.junit.jupiter.api.Test;
 
-import static com.revinate.assertj.json.JsonPathAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class CreateInstanceAcceptanceTest extends CloudFoundryAcceptanceTest {
@@ -87,14 +86,14 @@ class CreateInstanceAcceptanceTest extends CloudFoundryAcceptanceTest {
 	}
 
 	private void assertEnvironmentVariablesSet(DocumentContext json) {
-		assertThat(json).jsonPathAsString("$.ENV_VAR_1").isEqualTo("value1");
-		assertThat(json).jsonPathAsString("$.ENV_VAR_2").isEqualTo("value2");
+		assertThat(json.read("$.ENV_VAR_1").toString()).isEqualTo("value1");
+		assertThat(json.read("$.ENV_VAR_2").toString()).isEqualTo("value2");
 	}
 
 	private void assertBasicAuthCredentialsProvided(DocumentContext json) {
-		assertThat(json).jsonPathAsString("$.['spring.security.user.name']")
+		assertThat(json.read("$.['spring.security.user.name']").toString())
 			.matches("[a-zA-Z]{14}");
-		assertThat(json).jsonPathAsString("$.['spring.security.user.password']")
+		assertThat(json.read("$.['spring.security.user.password']").toString())
 			.matches("[a-zA-Z]{14}");
 	}
 }

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org.springframework.cloud.appbroker.acceptance/CreateInstanceWithOAuth2CredentialsAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org.springframework.cloud.appbroker.acceptance/CreateInstanceWithOAuth2CredentialsAcceptanceTest.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.appbroker.acceptance;
 
+import java.util.Optional;
+
 import com.jayway.jsonpath.DocumentContext;
 import org.cloudfoundry.operations.applications.ApplicationSummary;
 import org.cloudfoundry.uaa.clients.GetClientResponse;
@@ -23,9 +25,6 @@ import org.cloudfoundry.uaa.tokens.GrantType;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
-
-import static com.revinate.assertj.json.JsonPathAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Disabled("This test can only be run with a Cloud Foundry user or client that has 'client.write' authority, " +
@@ -66,9 +65,9 @@ class CreateInstanceWithOAuth2CredentialsAcceptanceTest extends CloudFoundryAcce
 
 		// and has the environment variables
 		DocumentContext json = getSpringAppJson(APP_NAME);
-		assertThat(json).jsonPathAsString("$.spring.security.oauth2.client.registration.sample-app-client.client-id")
+		assertThat(json.read("$.spring.security.oauth2.client.registration.sample-app-client.client-id").toString())
 			.isEqualTo(uaaClientId(serviceInstanceGuid));
-		assertThat(json).jsonPathAsString("$.spring.security.oauth2.client.registration.sample-app-client.client-secret")
+		assertThat(json.read("$.spring.security.oauth2.client.registration.sample-app-client.client-secret").toString())
 			.matches("[a-zA-Z]{12}");
 
 		// and a UAA client is created

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org.springframework.cloud.appbroker.acceptance/CreateInstanceWithParametersAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org.springframework.cloud.appbroker.acceptance/CreateInstanceWithParametersAcceptanceTest.java
@@ -24,7 +24,6 @@ import com.jayway.jsonpath.DocumentContext;
 import org.cloudfoundry.operations.applications.ApplicationSummary;
 import org.junit.jupiter.api.Test;
 
-import static com.revinate.assertj.json.JsonPathAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class CreateInstanceWithParametersAcceptanceTest extends CloudFoundryAcceptanceTest {
@@ -70,9 +69,9 @@ class CreateInstanceWithParametersAcceptanceTest extends CloudFoundryAcceptanceT
 
 		// and has the environment variables
 		DocumentContext json = getSpringAppJson(APP_NAME);
-		assertThat(json).jsonPathAsString("$.parameter1").isEqualTo("value1");
-		assertThat(json).jsonPathAsString("$.parameter2").isEqualTo("config2");
-		assertThat(json).jsonPathAsString("$.parameter3").isEqualTo("value3");
+		assertThat(json.read("$.parameter1").toString()).isEqualTo("value1");
+		assertThat(json.read("$.parameter2").toString()).isEqualTo("config2");
+		assertThat(json.read("$.parameter3").toString()).isEqualTo("value3");
 
 		// when the service instance is deleted
 		deleteServiceInstance(SI_NAME);

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org.springframework.cloud.appbroker.acceptance/UpdateInstanceAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org.springframework.cloud.appbroker.acceptance/UpdateInstanceAcceptanceTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
-import static com.revinate.assertj.json.JsonPathAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class UpdateInstanceAcceptanceTest extends CloudFoundryAcceptanceTest {
@@ -61,9 +60,9 @@ class UpdateInstanceAcceptanceTest extends CloudFoundryAcceptanceTest {
 			assertThat(app.getRunningInstances()).isEqualTo(1));
 
 		DocumentContext json = getSpringAppJson(APP_NAME);
-		assertThat(json).jsonPathAsString("$.parameter1").isEqualTo("config1");
-		assertThat(json).jsonPathAsString("$.parameter2").isEqualTo("config2");
-		assertThat(json).jsonPathAsString("$.parameter3").isEqualTo("config3");
+		assertThat(json.read("$.parameter1").toString()).isEqualTo("config1");
+		assertThat(json.read("$.parameter2").toString()).isEqualTo("config2");
+		assertThat(json.read("$.parameter3").toString()).isEqualTo("config3");
 
 		String path = backingApplication.get().getUrls().get(0);
 		healthListener.start(path);
@@ -82,10 +81,10 @@ class UpdateInstanceAcceptanceTest extends CloudFoundryAcceptanceTest {
 
 		// the backing application is updated with the new parameters
 		json = getSpringAppJson(APP_NAME);
-		assertThat(json).jsonPathAsString("$.parameter1").isEqualTo("value1");
-		assertThat(json).jsonPathAsString("$.parameter2").isEqualTo("config2");
-		assertThat(json).jsonPathAsString("$.parameter3").isEqualTo("value3");
-		assertThat(json).jsonPathAsString("$.parameter4").isEqualTo("config4");
+		assertThat(json.read("$.parameter1").toString()).isEqualTo("value1");
+		assertThat(json.read("$.parameter2").toString()).isEqualTo("config2");
+		assertThat(json.read("$.parameter3").toString()).isEqualTo("value3");
+		assertThat(json.read("$.parameter4").toString()).isEqualTo("config4");
 
 		// when the service instance is deleted
 		deleteServiceInstance(SI_NAME);

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org.springframework.cloud.appbroker.acceptance/UpdateInstanceWithTargetAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org.springframework.cloud.appbroker.acceptance/UpdateInstanceWithTargetAcceptanceTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
-import static com.revinate.assertj.json.JsonPathAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class UpdateInstanceWithTargetAcceptanceTest extends CloudFoundryAcceptanceTest {
@@ -77,7 +76,7 @@ class UpdateInstanceWithTargetAcceptanceTest extends CloudFoundryAcceptanceTest 
 
 		// then the service instance has the initial parameters
 		DocumentContext json = getSpringAppJson(APP_NAME, spaceName);
-		assertThat(json).jsonPathAsString("$.parameter1").isEqualTo("config1");
+		assertThat(json.read("$.parameter1").toString()).isEqualTo("config1");
 
 		// when the service instance is deleted
 		deleteServiceInstance(SI_NAME);

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org.springframework.cloud.appbroker.acceptance/fixtures/cf/CloudFoundryService.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org.springframework.cloud.appbroker.acceptance/fixtures/cf/CloudFoundryService.java
@@ -32,6 +32,7 @@ import org.cloudfoundry.operations.applications.DeleteApplicationRequest;
 import org.cloudfoundry.operations.applications.GetApplicationEnvironmentsRequest;
 import org.cloudfoundry.operations.applications.GetApplicationRequest;
 import org.cloudfoundry.operations.applications.PushApplicationManifestRequest;
+import org.cloudfoundry.operations.applications.StopApplicationRequest;
 import org.cloudfoundry.operations.organizations.CreateOrganizationRequest;
 import org.cloudfoundry.operations.organizations.OrganizationSummary;
 import org.cloudfoundry.operations.organizations.Organizations;
@@ -93,7 +94,7 @@ public class CloudFoundryService {
 				.doOnError(error -> LOGGER.error("Error creating service broker " + brokerName + ": " + error)));
 	}
 
-	private Mono<String> getApplicationRoute(String appName) {
+	public Mono<String> getApplicationRoute(String appName) {
 		return cloudFoundryOperations.applications()
 			.get(GetApplicationRequest.builder()
 				.name(appName)
@@ -203,7 +204,13 @@ public class CloudFoundryService {
 			.collectList();
 	}
 
-	public Mono<ApplicationSummary> getApplicationSummary(String appName, String space) {
+	public Mono<ApplicationDetail> getApplication(String appName) {
+		return cloudFoundryOperations.applications().get(GetApplicationRequest.builder()
+			.name(appName)
+			.build());
+	}
+
+	public Mono<ApplicationSummary> getApplication(String appName, String space) {
 		return listApplications(createOperationsForSpace(space))
 			.filter(applicationSummary -> applicationSummary.getName().equals(appName))
 			.single();
@@ -231,6 +238,12 @@ public class CloudFoundryService {
 				.build())
 			.doOnSuccess(item -> LOGGER.info("Got environment for application " + appName))
 			.doOnError(error -> LOGGER.error("Error getting environment for application " + appName + ": " + error));
+	}
+
+	public Mono<Void> stopApplication(String appName) {
+		return cloudFoundryOperations.applications().stop(StopApplicationRequest.builder()
+			.name(appName)
+			.build());
 	}
 
 	public Mono<List<String>> getSpaces() {

--- a/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfiguration.java
+++ b/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfiguration.java
@@ -46,6 +46,9 @@ import org.springframework.cloud.appbroker.extensions.targets.ServiceInstanceGui
 import org.springframework.cloud.appbroker.extensions.targets.SpacePerServiceInstance;
 import org.springframework.cloud.appbroker.extensions.targets.TargetFactory;
 import org.springframework.cloud.appbroker.extensions.targets.TargetService;
+import org.springframework.cloud.appbroker.manager.AppManager;
+import org.springframework.cloud.appbroker.manager.BackingAppManagementService;
+import org.springframework.cloud.appbroker.manager.ManagementClient;
 import org.springframework.cloud.appbroker.oauth2.OAuth2Client;
 import org.springframework.cloud.appbroker.service.CreateServiceInstanceAppBindingWorkflow;
 import org.springframework.cloud.appbroker.service.CreateServiceInstanceRouteBindingWorkflow;
@@ -74,13 +77,24 @@ public class AppBrokerAutoConfiguration {
 	private static final String PROPERTY_PREFIX = "spring.cloud.appbroker";
 
 	@Bean
+	public DeployerClient deployerClient(AppDeployer appDeployer) {
+		return new DeployerClient(appDeployer);
+	}
+
+	@Bean
 	public BackingAppDeploymentService backingAppDeploymentService(DeployerClient deployerClient) {
 		return new BackingAppDeploymentService(deployerClient);
 	}
 
 	@Bean
-	public DeployerClient deployerClient(AppDeployer appDeployer) {
-		return new DeployerClient(appDeployer);
+	public ManagementClient managementClient(AppManager appManager) {
+		return new ManagementClient(appManager);
+	}
+
+	@Bean
+	public BackingAppManagementService backingAppManagementService(ManagementClient managementClient,
+		AppDeployer appDeployer, BrokeredServices brokeredServices, TargetService targetService) {
+		return new BackingAppManagementService(managementClient, appDeployer, brokeredServices, targetService);
 	}
 
 	@Bean

--- a/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfigurationTest.java
+++ b/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfigurationTest.java
@@ -41,6 +41,8 @@ import org.springframework.cloud.appbroker.extensions.parameters.PropertyMapping
 import org.springframework.cloud.appbroker.extensions.targets.ServiceInstanceGuidSuffix;
 import org.springframework.cloud.appbroker.extensions.targets.SpacePerServiceInstance;
 import org.springframework.cloud.appbroker.extensions.targets.TargetService;
+import org.springframework.cloud.appbroker.manager.BackingAppManagementService;
+import org.springframework.cloud.appbroker.manager.ManagementClient;
 import org.springframework.cloud.appbroker.service.CreateServiceInstanceAppBindingWorkflow;
 import org.springframework.cloud.appbroker.service.CreateServiceInstanceRouteBindingWorkflow;
 import org.springframework.cloud.appbroker.service.DeleteServiceInstanceBindingWorkflow;
@@ -164,12 +166,14 @@ class AppBrokerAutoConfigurationTest {
 
 	private void assertBeansCreated(AssertableApplicationContext context) {
 		assertThat(context).hasSingleBean(DeployerClient.class);
+		assertThat(context).hasSingleBean(ManagementClient.class);
 		assertThat(context).hasSingleBean(BrokeredServices.class);
 
 		assertThat(context).hasSingleBean(ServiceInstanceStateRepository.class);
 		assertThat(context).hasSingleBean(ServiceInstanceBindingStateRepository.class);
 
 		assertThat(context).hasSingleBean(BackingAppDeploymentService.class);
+		assertThat(context).hasSingleBean(BackingAppManagementService.class);
 		assertThat(context).hasSingleBean(BackingServicesProvisionService.class);
 
 		assertThat(context).hasSingleBean(BackingApplicationsParametersTransformationService.class);

--- a/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/CloudFoundryAppDeployerAutoConfigurationTest.java
+++ b/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/CloudFoundryAppDeployerAutoConfigurationTest.java
@@ -31,7 +31,9 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cloud.appbroker.deployer.AppDeployer;
 import org.springframework.cloud.appbroker.deployer.cloudfoundry.CloudFoundryDeploymentProperties;
+import org.springframework.cloud.appbroker.deployer.cloudfoundry.CloudFoundryOperationsUtils;
 import org.springframework.cloud.appbroker.deployer.cloudfoundry.CloudFoundryTargetProperties;
+import org.springframework.cloud.appbroker.manager.AppManager;
 import org.springframework.cloud.appbroker.oauth2.OAuth2Client;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -74,12 +76,14 @@ class CloudFoundryAppDeployerAutoConfigurationTest {
 				assertThat(deploymentProperties.getDomain()).isEqualTo("example.com");
 
 				assertThat(context).hasSingleBean(AppDeployer.class);
+				assertThat(context).hasSingleBean(AppManager.class);
 				assertThat(context).hasSingleBean(OAuth2Client.class);
 
 				assertThat(context).hasSingleBean(ReactorCloudFoundryClient.class);
 				assertThat(context).hasSingleBean(ReactorDopplerClient.class);
 				assertThat(context).hasSingleBean(ReactorUaaClient.class);
 				assertThat(context).hasSingleBean(CloudFoundryOperations.class);
+				assertThat(context).hasSingleBean(CloudFoundryOperationsUtils.class);
 				assertThat(context).hasSingleBean(DefaultConnectionContext.class);
 				assertThat(context).hasSingleBean(PasswordGrantTokenProvider.class);
 			});
@@ -107,11 +111,13 @@ class CloudFoundryAppDeployerAutoConfigurationTest {
 				assertThat(targetProperties.getClientSecret()).isEqualTo("secret");
 
 				assertThat(context).hasSingleBean(AppDeployer.class);
+				assertThat(context).hasSingleBean(AppManager.class);
 
 				assertThat(context).hasSingleBean(ReactorCloudFoundryClient.class);
 				assertThat(context).hasSingleBean(ReactorDopplerClient.class);
 				assertThat(context).hasSingleBean(ReactorUaaClient.class);
 				assertThat(context).hasSingleBean(CloudFoundryOperations.class);
+				assertThat(context).hasSingleBean(CloudFoundryOperationsUtils.class);
 				assertThat(context).hasSingleBean(DefaultConnectionContext.class);
 				assertThat(context).hasSingleBean(ClientCredentialsGrantTokenProvider.class);
 			});
@@ -127,6 +133,7 @@ class CloudFoundryAppDeployerAutoConfigurationTest {
 				assertThat(context).doesNotHaveBean(ReactorDopplerClient.class);
 				assertThat(context).doesNotHaveBean(ReactorUaaClient.class);
 				assertThat(context).doesNotHaveBean(CloudFoundryOperations.class);
+				assertThat(context).doesNotHaveBean(CloudFoundryOperationsUtils.class);
 				assertThat(context).doesNotHaveBean(ConnectionContext.class);
 				assertThat(context).doesNotHaveBean(TokenProvider.class);
 			});

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/BackingApplications.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/BackingApplications.java
@@ -19,6 +19,8 @@ package org.springframework.cloud.appbroker.deployer;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.util.CollectionUtils;
+
 public class BackingApplications extends ArrayList<BackingApplication> {
 	private static final long serialVersionUID = 159473836238657105L;
 
@@ -43,6 +45,13 @@ public class BackingApplications extends ArrayList<BackingApplication> {
 
 		public BackingApplicationsBuilder backingApplication(BackingApplication backingApplication) {
 			this.backingApplications.add(backingApplication);
+			return this;
+		}
+
+		public BackingApplicationsBuilder backingApplications(List<BackingApplication> backingApplications) {
+			if (!CollectionUtils.isEmpty(backingApplications)) {
+				this.backingApplications.addAll(backingApplications);
+			}
 			return this;
 		}
 

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/manager/BackingAppManagementService.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/manager/BackingAppManagementService.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2016-2019 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.manager;
+
+import java.util.List;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.Logger;
+import reactor.util.Loggers;
+
+import org.springframework.cloud.appbroker.deployer.AppDeployer;
+import org.springframework.cloud.appbroker.deployer.BackingApplication;
+import org.springframework.cloud.appbroker.deployer.BackingApplications;
+import org.springframework.cloud.appbroker.deployer.BrokeredService;
+import org.springframework.cloud.appbroker.deployer.BrokeredServices;
+import org.springframework.cloud.appbroker.deployer.GetServiceInstanceRequest;
+import org.springframework.cloud.appbroker.extensions.targets.TargetService;
+
+public class BackingAppManagementService {
+
+	private final Logger log = Loggers.getLogger(BackingAppManagementService.class);
+
+	private final ManagementClient managementClient;
+
+	private final AppDeployer appDeployer;
+
+	private final BrokeredServices brokeredServices;
+
+	private final TargetService targetService;
+
+	public BackingAppManagementService(ManagementClient managementClient, AppDeployer appDeployer,
+		BrokeredServices brokeredServices, TargetService targetService) {
+		this.managementClient = managementClient;
+		this.appDeployer = appDeployer;
+		this.brokeredServices = brokeredServices;
+		this.targetService = targetService;
+	}
+
+	public Mono<Void> stop(String serviceInstanceId) {
+		return getBackingApplicationsForService(serviceInstanceId)
+			.flatMapMany(backingApps -> Flux.fromIterable(backingApps)
+				.parallel()
+				.runOn(Schedulers.parallel())
+				.flatMap(managementClient::stop)
+				.doOnRequest(l -> log.debug("Stopping applications {}", backingApps))
+				.doOnEach(response -> log.debug("Finished stopping application {}", response))
+				.doOnComplete(() -> log.debug("Finished stopping application {}", backingApps))
+				.doOnError(exception -> log.error("Error stopping applications {} with error '{}'",
+					backingApps, exception.getMessage())))
+			.then();
+	}
+
+	public Mono<Void> start(String serviceInstanceId) {
+		return getBackingApplicationsForService(serviceInstanceId)
+			.flatMapMany(backingApps -> Flux.fromIterable(backingApps)
+				.parallel()
+				.runOn(Schedulers.parallel())
+				.flatMap(managementClient::start)
+				.doOnRequest(l -> log.debug("Starting applications {}", backingApps))
+				.doOnEach(response -> log.debug("Finished starting application {}", response))
+				.doOnComplete(() -> log.debug("Finished starting application {}", backingApps))
+				.doOnError(exception -> log.error("Error starting applications {} with error '{}'",
+					backingApps, exception.getMessage())))
+			.then();
+	}
+
+	public Mono<Void> restart(String serviceInstanceId) {
+		return getBackingApplicationsForService(serviceInstanceId)
+			.flatMapMany(backingApps -> Flux.fromIterable(backingApps)
+				.parallel()
+				.runOn(Schedulers.parallel())
+				.flatMap(managementClient::restart)
+				.doOnRequest(l -> log.debug("Restarting applications {}", backingApps))
+				.doOnEach(response -> log.debug("Finished restarting application {}", response))
+				.doOnComplete(() -> log.debug("Finished restarting application {}", backingApps))
+				.doOnError(exception -> log.error("Error restarting applications {} with error '{}'",
+					backingApps, exception.getMessage())))
+			.then();
+	}
+
+	public Mono<Void> restage(String serviceInstanceId) {
+		return getBackingApplicationsForService(serviceInstanceId)
+			.flatMapMany(backingApps -> Flux.fromIterable(backingApps)
+				.parallel()
+				.runOn(Schedulers.parallel())
+				.flatMap(managementClient::restage)
+				.doOnRequest(l -> log.debug("Restaging applications {}", backingApps))
+				.doOnEach(response -> log.debug("Finished restaging application {}", response))
+				.doOnComplete(() -> log.debug("Finished restaging application {}", backingApps))
+				.doOnError(exception -> log.error("Error restaging applications {} with error '{}'",
+					backingApps, exception.getMessage())))
+			.then();
+	}
+
+	private Mono<List<BackingApplication>> getBackingApplicationsForService(String serviceInstanceId) {
+		return appDeployer.getServiceInstance(GetServiceInstanceRequest.builder()
+			.serviceInstanceId(serviceInstanceId)
+			.build())
+			.flatMap(response -> findBrokeredService(response.getService(), response.getPlan()))
+			.flatMap(brokeredService -> updateBackingApps(brokeredService, serviceInstanceId));
+	}
+
+	private Mono<BrokeredService> findBrokeredService(String serviceName, String planName) {
+		return Flux.fromIterable(brokeredServices)
+			.filter(brokeredService -> brokeredService.getServiceName().equals(serviceName)
+				&& brokeredService.getPlanName().equals(planName))
+			.singleOrEmpty();
+	}
+
+	private Mono<List<BackingApplication>> updateBackingApps(BrokeredService brokeredService,
+		String serviceInstanceId) {
+		return Mono.just(BackingApplications.builder()
+			.backingApplications(brokeredService.getApps())
+			.build())
+			.flatMap(backingApps -> targetService.addToBackingApplications(backingApps,
+				brokeredService.getTarget(), serviceInstanceId));
+	}
+
+}

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/manager/ManagementClient.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/manager/ManagementClient.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016-2019 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.manager;
+
+import reactor.core.publisher.Mono;
+import reactor.util.Logger;
+import reactor.util.Loggers;
+
+import org.springframework.cloud.appbroker.deployer.BackingApplication;
+
+public class ManagementClient {
+
+	private final Logger log = Loggers.getLogger(ManagementClient.class);
+
+	private final AppManager appManager;
+
+	public ManagementClient(AppManager appManager) {
+		this.appManager = appManager;
+	}
+
+	Mono<Void> start(BackingApplication backingApplication) {
+		return Mono.justOrEmpty(backingApplication)
+			.flatMap(backingApp -> appManager.start(StartApplicationRequest.builder()
+				.name(backingApp.getName())
+				.properties(backingApp.getProperties())
+				.build())
+				.doOnRequest(l -> log.debug("Starting application {}", backingApp))
+				.doOnSuccess(response -> log.debug("Finished starting application {}", backingApp))
+				.doOnError(exception -> log.error("Error starting application {} with error '{}'",
+					backingApp, exception.getMessage())));
+	}
+
+	Mono<Void> stop(BackingApplication backingApplication) {
+		return Mono.justOrEmpty(backingApplication)
+			.flatMap(backingApp -> appManager.stop(StopApplicationRequest.builder()
+				.name(backingApp.getName())
+				.properties(backingApp.getProperties())
+				.build())
+				.doOnRequest(l -> log.debug("Stopping application {}", backingApp))
+				.doOnSuccess(response -> log.debug("Finished stopping application {}", backingApp))
+				.doOnError(exception -> log.error("Error stopping application {} with error '{}'",
+					backingApp, exception.getMessage())));
+	}
+
+	Mono<Void> restart(BackingApplication backingApplication) {
+		return Mono.justOrEmpty(backingApplication)
+			.flatMap(backingApp -> appManager.restart(RestartApplicationRequest.builder()
+				.name(backingApp.getName())
+				.properties(backingApp.getProperties())
+				.build())
+				.doOnRequest(l -> log.debug("Restarting application {}", backingApp))
+				.doOnSuccess(response -> log.debug("Finished restarting application {}", backingApp))
+				.doOnError(exception -> log.error("Error restarting application {} with error '{}'",
+					backingApp, exception.getMessage())));
+	}
+
+	Mono<Void> restage(BackingApplication backingApplication) {
+		return Mono.justOrEmpty(backingApplication)
+			.flatMap(backingApp -> appManager.restage(RestageApplicationRequest.builder()
+				.name(backingApp.getName())
+				.properties(backingApp.getProperties())
+				.build())
+				.doOnRequest(l -> log.debug("Restaging application {}", backingApp))
+				.doOnSuccess(response -> log.debug("Finished restaging application {}", backingApp))
+				.doOnError(exception -> log.error("Error restaging application {} with error '{}'",
+					backingApp, exception.getMessage())));
+	}
+}

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/manager/BackingAppManagementServiceTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/manager/BackingAppManagementServiceTest.java
@@ -1,0 +1,389 @@
+/*
+ * Copyright 2016-2019 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.manager;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import org.springframework.cloud.appbroker.deployer.AppDeployer;
+import org.springframework.cloud.appbroker.deployer.BackingApplication;
+import org.springframework.cloud.appbroker.deployer.BackingApplications;
+import org.springframework.cloud.appbroker.deployer.BrokeredService;
+import org.springframework.cloud.appbroker.deployer.BrokeredServices;
+import org.springframework.cloud.appbroker.deployer.GetServiceInstanceRequest;
+import org.springframework.cloud.appbroker.deployer.GetServiceInstanceResponse;
+import org.springframework.cloud.appbroker.extensions.targets.TargetService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class BackingAppManagementServiceTest {
+
+	private BackingAppManagementService backingAppManagementService;
+
+	private BackingApplications backingApps;
+
+	@Mock
+	private ManagementClient managementClient;
+
+	@Mock
+	private AppDeployer appDeployer;
+
+	@Mock
+	private TargetService targetService;
+
+	@BeforeEach
+	void setUp() {
+		this.backingApps = BackingApplications.builder()
+			.backingApplication(BackingApplication.builder()
+				.name("testApp1")
+				.path("http://myfiles/app1.jar")
+				.build())
+			.backingApplication(BackingApplication.builder()
+				.name("testApp2")
+				.path("http://myfiles/app2.jar")
+				.build())
+			.build();
+
+		BrokeredServices brokeredServices = BrokeredServices
+			.builder()
+			.service(BrokeredService
+				.builder()
+				.serviceName("service1")
+				.planName("plan1")
+				.apps(backingApps)
+				.build())
+			.build();
+
+		this.backingAppManagementService = new BackingAppManagementService(managementClient, appDeployer,
+			brokeredServices,
+			targetService);
+	}
+
+	@Test
+	void stopApplications() {
+		doReturn(Mono.empty()).when(managementClient).stop(backingApps.get(0));
+		doReturn(Mono.empty()).when(managementClient).stop(backingApps.get(1));
+
+		given(appDeployer.getServiceInstance(any(GetServiceInstanceRequest.class)))
+			.willReturn(Mono.just(GetServiceInstanceResponse.builder()
+				.name("foo-service")
+				.plan("plan1")
+				.service("service1")
+				.build()));
+
+		given(targetService.addToBackingApplications(eq(backingApps), any(), eq("foo-service-id")))
+			.willReturn(Mono.just(backingApps));
+
+		StepVerifier.create(backingAppManagementService.stop("foo-service-id"))
+			.expectNext()
+			.expectNext()
+			.verifyComplete();
+
+		verify(appDeployer).getServiceInstance(any(GetServiceInstanceRequest.class));
+		verify(targetService).addToBackingApplications(eq(backingApps), any(), eq("foo-service-id"));
+		verify(managementClient, times(2)).stop(any(BackingApplication.class));
+		verifyNoMoreInteractions(appDeployer, targetService, managementClient);
+	}
+
+	@Test
+	void stopApplicationsWithEmptyApplications() {
+		BackingApplications emptyBackingApps = BackingApplications.builder().build();
+
+		BrokeredServices brokeredServicesNoApps = BrokeredServices
+			.builder()
+			.service(BrokeredService
+				.builder()
+				.serviceName("service1")
+				.planName("plan1")
+				.apps(emptyBackingApps)
+				.build())
+			.build();
+
+		this.backingAppManagementService = new BackingAppManagementService(managementClient, appDeployer,
+			brokeredServicesNoApps,
+			targetService);
+
+		given(appDeployer.getServiceInstance(any(GetServiceInstanceRequest.class)))
+			.willReturn(Mono.just(GetServiceInstanceResponse.builder()
+				.name("foo-service")
+				.plan("plan1")
+				.service("service1")
+				.build()));
+
+		given(targetService.addToBackingApplications(eq(emptyBackingApps), any(), eq("foo-service-id")))
+			.willReturn(Mono.just(emptyBackingApps));
+
+		StepVerifier.create(backingAppManagementService.stop("foo-service-id"))
+			.verifyComplete();
+
+		verify(appDeployer).getServiceInstance(any(GetServiceInstanceRequest.class));
+		verify(targetService).addToBackingApplications(eq(emptyBackingApps), any(), eq("foo-service-id"));
+		verifyZeroInteractions(managementClient);
+		verifyNoMoreInteractions(appDeployer, targetService, managementClient);
+	}
+
+	@Test
+	void stopApplicationsServiceNotFound() {
+		given(appDeployer.getServiceInstance(any(GetServiceInstanceRequest.class)))
+			.willReturn(Mono.just(GetServiceInstanceResponse.builder()
+				.build()));
+
+		StepVerifier.create(backingAppManagementService.stop("unknown-service-id"))
+			.verifyComplete();
+
+		verifyNoMoreInteractions(appDeployer, targetService, managementClient);
+	}
+
+	@Test
+	void startApplications() {
+		given(appDeployer.getServiceInstance(any(GetServiceInstanceRequest.class)))
+			.willReturn(Mono.just(GetServiceInstanceResponse.builder()
+				.name("foo-service")
+				.plan("plan1")
+				.service("service1")
+				.build()));
+
+		given(targetService.addToBackingApplications(eq(backingApps), any(), eq("foo-service-id")))
+			.willReturn(Mono.just(backingApps));
+
+		doReturn(Mono.empty()).when(managementClient).start(backingApps.get(0));
+		doReturn(Mono.empty()).when(managementClient).start(backingApps.get(1));
+
+		StepVerifier.create(backingAppManagementService.start("foo-service-id"))
+			.expectNext()
+			.expectNext()
+			.verifyComplete();
+
+		verify(appDeployer).getServiceInstance(any(GetServiceInstanceRequest.class));
+		verify(targetService).addToBackingApplications(eq(backingApps), any(), eq("foo-service-id"));
+		verify(managementClient, times(2)).start(any(BackingApplication.class));
+		verifyNoMoreInteractions(appDeployer, targetService, managementClient);
+	}
+
+	@Test
+	void startApplicationsServiceNotFound() {
+		given(appDeployer.getServiceInstance(any(GetServiceInstanceRequest.class)))
+			.willReturn(Mono.just(GetServiceInstanceResponse.builder()
+				.build()));
+
+		StepVerifier.create(backingAppManagementService.start("unknown-service-id"))
+			.verifyComplete();
+
+		verifyNoMoreInteractions(appDeployer, targetService, managementClient);
+	}
+
+	@Test
+	void startApplicationsWithEmptyApplications() {
+		BackingApplications emptyBackingApps = BackingApplications.builder().build();
+
+		BrokeredServices brokeredServicesNoApps = BrokeredServices
+			.builder()
+			.service(BrokeredService
+				.builder()
+				.serviceName("service1")
+				.planName("plan1")
+				.apps(emptyBackingApps)
+				.build())
+			.build();
+
+		this.backingAppManagementService = new BackingAppManagementService(managementClient, appDeployer,
+			brokeredServicesNoApps,
+			targetService);
+
+		given(appDeployer.getServiceInstance(any(GetServiceInstanceRequest.class)))
+			.willReturn(Mono.just(GetServiceInstanceResponse.builder()
+				.name("foo-service")
+				.plan("plan1")
+				.service("service1")
+				.build()));
+
+		given(targetService.addToBackingApplications(eq(emptyBackingApps), any(), eq("foo-service-id")))
+			.willReturn(Mono.just(emptyBackingApps));
+
+		StepVerifier.create(backingAppManagementService.start("foo-service-id"))
+			.verifyComplete();
+
+		verify(appDeployer).getServiceInstance(any(GetServiceInstanceRequest.class));
+		verify(targetService).addToBackingApplications(eq(emptyBackingApps), any(), eq("foo-service-id"));
+		verifyZeroInteractions(managementClient);
+		verifyNoMoreInteractions(appDeployer, targetService, managementClient);
+	}
+
+	@Test
+	void restartApplications() {
+		given(appDeployer.getServiceInstance(any(GetServiceInstanceRequest.class)))
+			.willReturn(Mono.just(GetServiceInstanceResponse.builder()
+				.name("foo-service")
+				.plan("plan1")
+				.service("service1")
+				.build()));
+
+		given(targetService.addToBackingApplications(eq(backingApps), any(), eq("foo-service-id")))
+			.willReturn(Mono.just(backingApps));
+
+		doReturn(Mono.empty()).when(managementClient).restart(backingApps.get(0));
+		doReturn(Mono.empty()).when(managementClient).restart(backingApps.get(1));
+
+		StepVerifier.create(backingAppManagementService.restart("foo-service-id"))
+			.expectNext()
+			.expectNext()
+			.verifyComplete();
+
+		verify(appDeployer).getServiceInstance(any(GetServiceInstanceRequest.class));
+		verify(targetService).addToBackingApplications(eq(backingApps), any(), eq("foo-service-id"));
+		verify(managementClient, times(2)).restart(any(BackingApplication.class));
+		verifyNoMoreInteractions(appDeployer, targetService, managementClient);
+	}
+
+	@Test
+	void restartApplicationsServiceNotFound() {
+		given(appDeployer.getServiceInstance(any(GetServiceInstanceRequest.class)))
+			.willReturn(Mono.just(GetServiceInstanceResponse.builder()
+				.build()));
+
+		StepVerifier.create(backingAppManagementService.restart("unknown-service-id"))
+			.verifyComplete();
+
+		verifyNoMoreInteractions(appDeployer, targetService, managementClient);
+	}
+
+	@Test
+	void restartApplicationsWithEmptyApplications() {
+		BackingApplications emptyBackingApps = BackingApplications.builder().build();
+
+		BrokeredServices brokeredServicesNoApps = BrokeredServices
+			.builder()
+			.service(BrokeredService
+				.builder()
+				.serviceName("service1")
+				.planName("plan1")
+				.apps(emptyBackingApps)
+				.build())
+			.build();
+
+		this.backingAppManagementService = new BackingAppManagementService(managementClient, appDeployer,
+			brokeredServicesNoApps,
+			targetService);
+
+		given(appDeployer.getServiceInstance(any(GetServiceInstanceRequest.class)))
+			.willReturn(Mono.just(GetServiceInstanceResponse.builder()
+				.name("foo-service")
+				.plan("plan1")
+				.service("service1")
+				.build()));
+
+		given(targetService.addToBackingApplications(eq(emptyBackingApps), any(), eq("foo-service-id")))
+			.willReturn(Mono.just(emptyBackingApps));
+
+		StepVerifier.create(backingAppManagementService.restart("foo-service-id"))
+			.verifyComplete();
+
+		verify(appDeployer).getServiceInstance(any(GetServiceInstanceRequest.class));
+		verify(targetService).addToBackingApplications(eq(emptyBackingApps), any(), eq("foo-service-id"));
+		verifyZeroInteractions(managementClient);
+		verifyNoMoreInteractions(appDeployer, targetService, managementClient);
+	}
+
+	@Test
+	void restageApplications() {
+		given(appDeployer.getServiceInstance(any(GetServiceInstanceRequest.class)))
+			.willReturn(Mono.just(GetServiceInstanceResponse.builder()
+				.name("foo-service")
+				.plan("plan1")
+				.service("service1")
+				.build()));
+
+		given(targetService.addToBackingApplications(eq(backingApps), any(), eq("foo-service-id")))
+			.willReturn(Mono.just(backingApps));
+
+		doReturn(Mono.empty()).when(managementClient).restage(backingApps.get(0));
+		doReturn(Mono.empty()).when(managementClient).restage(backingApps.get(1));
+
+		StepVerifier.create(backingAppManagementService.restage("foo-service-id"))
+			.expectNext()
+			.expectNext()
+			.verifyComplete();
+
+		verify(appDeployer).getServiceInstance(any(GetServiceInstanceRequest.class));
+		verify(targetService).addToBackingApplications(eq(backingApps), any(), eq("foo-service-id"));
+		verify(managementClient, times(2)).restage(any(BackingApplication.class));
+		verifyNoMoreInteractions(appDeployer, targetService, managementClient);
+	}
+
+	@Test
+	void restageApplicationsServiceNotFound() {
+		given(appDeployer.getServiceInstance(any(GetServiceInstanceRequest.class)))
+			.willReturn(Mono.just(GetServiceInstanceResponse.builder()
+				.build()));
+
+		StepVerifier.create(backingAppManagementService.restage("unknown-service-id"))
+			.verifyComplete();
+
+		verifyNoMoreInteractions(appDeployer, targetService, managementClient);
+	}
+
+	@Test
+	void restageApplicationsWithEmptyApplications() {
+		BackingApplications emptyBackingApps = BackingApplications.builder().build();
+
+		BrokeredServices brokeredServicesNoApps = BrokeredServices
+			.builder()
+			.service(BrokeredService
+				.builder()
+				.serviceName("service1")
+				.planName("plan1")
+				.apps(emptyBackingApps)
+				.build())
+			.build();
+
+		this.backingAppManagementService = new BackingAppManagementService(managementClient, appDeployer,
+			brokeredServicesNoApps,
+			targetService);
+
+		given(appDeployer.getServiceInstance(any(GetServiceInstanceRequest.class)))
+			.willReturn(Mono.just(GetServiceInstanceResponse.builder()
+				.name("foo-service")
+				.plan("plan1")
+				.service("service1")
+				.build()));
+
+		given(targetService.addToBackingApplications(eq(emptyBackingApps), any(), eq("foo-service-id")))
+			.willReturn(Mono.just(emptyBackingApps));
+
+		StepVerifier.create(backingAppManagementService.restage("foo-service-id"))
+			.verifyComplete();
+
+		verify(appDeployer).getServiceInstance(any(GetServiceInstanceRequest.class));
+		verify(targetService).addToBackingApplications(eq(emptyBackingApps), any(), eq("foo-service-id"));
+		verifyZeroInteractions(managementClient);
+		verifyNoMoreInteractions(appDeployer, targetService, managementClient);
+	}
+
+}

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/manager/ManagementClientTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/manager/ManagementClientTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2016-2019 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.manager;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import org.springframework.cloud.appbroker.deployer.BackingApplication;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class ManagementClientTest {
+
+	private ManagementClient managementClient;
+
+	@Mock
+	private AppManager appManager;
+
+	private BackingApplication backingApplication;
+
+	@BeforeEach
+	void setUp() {
+		this.managementClient = new ManagementClient(appManager);
+
+		this.backingApplication = BackingApplication.builder()
+			.name("foo-app")
+			.property("foo", "bar")
+			.build();
+	}
+
+	@Test
+	void startApplication() {
+		given(appManager.start(any(StartApplicationRequest.class)))
+			.willReturn(Mono.empty());
+
+		StepVerifier.create(managementClient.start(backingApplication))
+			.verifyComplete();
+
+		verify(appManager).start(argThat(request -> "foo-app".equals(request.getName()) &&
+			Collections.singletonMap("foo", "bar").equals(request.getProperties())));
+		verifyNoMoreInteractions(appManager);
+	}
+
+	@Test
+	void startNullApplication() {
+		StepVerifier.create(managementClient.start(null))
+			.verifyComplete();
+
+		verifyZeroInteractions(appManager);
+	}
+
+	@Test
+	void stopApplication() {
+		given(appManager.stop(any(StopApplicationRequest.class)))
+			.willReturn(Mono.empty());
+
+		StepVerifier.create(managementClient.stop(backingApplication))
+			.verifyComplete();
+
+		verify(appManager).stop(argThat(request -> "foo-app".equals(request.getName()) &&
+			Collections.singletonMap("foo", "bar").equals(request.getProperties())));
+		verifyNoMoreInteractions(appManager);
+	}
+
+	@Test
+	void stopNullApplication() {
+		StepVerifier.create(managementClient.stop(null))
+			.verifyComplete();
+
+		verifyZeroInteractions(appManager);
+	}
+
+	@Test
+	void restartApplication() {
+		given(appManager.restart(any(RestartApplicationRequest.class)))
+			.willReturn(Mono.empty());
+
+		StepVerifier.create(managementClient.restart(backingApplication))
+			.verifyComplete();
+
+		verify(appManager).restart(argThat(request -> "foo-app".equals(request.getName()) &&
+			Collections.singletonMap("foo", "bar").equals(request.getProperties())));
+		verifyNoMoreInteractions(appManager);
+	}
+
+	@Test
+	void restartNullApplication() {
+		StepVerifier.create(managementClient.restart(null))
+			.verifyComplete();
+
+		verifyZeroInteractions(appManager);
+	}
+
+	@Test
+	void restageApplication() {
+		given(appManager.restage(any(RestageApplicationRequest.class)))
+			.willReturn(Mono.empty());
+
+		StepVerifier.create(managementClient.restage(backingApplication))
+			.verifyComplete();
+
+		verify(appManager).restage(argThat(request -> "foo-app".equals(request.getName()) &&
+			Collections.singletonMap("foo", "bar").equals(request.getProperties())));
+		verifyNoMoreInteractions(appManager);
+	}
+
+	@Test
+	void restageNullApplication() {
+		StepVerifier.create(managementClient.restage(null))
+			.verifyComplete();
+
+		verifyZeroInteractions(appManager);
+	}
+}

--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppManager.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppManager.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2016-2019 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.deployer.cloudfoundry;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+import org.springframework.cloud.appbroker.manager.AppManager;
+import org.springframework.cloud.appbroker.manager.RestageApplicationRequest;
+import org.springframework.cloud.appbroker.manager.RestartApplicationRequest;
+import org.springframework.cloud.appbroker.manager.StartApplicationRequest;
+import org.springframework.cloud.appbroker.manager.StopApplicationRequest;
+
+public class CloudFoundryAppManager implements AppManager {
+
+	private final Logger logger = LoggerFactory.getLogger(CloudFoundryAppManager.class);
+
+	private final CloudFoundryOperationsUtils operationsUtils;
+
+	public CloudFoundryAppManager(CloudFoundryOperationsUtils operationsUtils) {
+		this.operationsUtils = operationsUtils;
+	}
+
+	@Override
+	public Mono<Void> start(StartApplicationRequest request) {
+		return Mono.justOrEmpty(request)
+			.flatMap(req -> operationsUtils.getOperations(req.getProperties())
+				.flatMap(cfOperations -> Mono.justOrEmpty(req.getName())
+					.flatMap(appName -> cfOperations.applications().start(
+						org.cloudfoundry.operations.applications.StartApplicationRequest.builder()
+							.name(appName)
+							.build())
+						.doOnRequest(l -> logger.debug("Starting application {}", appName))
+						.doOnSuccess(item -> logger.info("Successfully started application {}", appName))
+						.doOnError(error -> logger.error("Failed to start application {}", appName)))));
+	}
+
+	@Override
+	public Mono<Void> stop(StopApplicationRequest request) {
+		return Mono.justOrEmpty(request)
+			.flatMap(req -> operationsUtils.getOperations(req.getProperties())
+				.flatMap(cfOperations -> Mono.justOrEmpty(req.getName())
+					.flatMap(appName -> cfOperations.applications().stop(
+						org.cloudfoundry.operations.applications.StopApplicationRequest.builder()
+							.name(appName)
+							.build())
+						.doOnRequest(l -> logger.debug("Stopping application {}", appName))
+						.doOnSuccess(item -> logger.info("Successfully stopped application {}", appName))
+						.doOnError(error -> logger.error("Failed to stop application {}", appName)))));
+	}
+
+	@Override
+	public Mono<Void> restart(RestartApplicationRequest request) {
+		return Mono.justOrEmpty(request)
+			.flatMap(req -> operationsUtils.getOperations(req.getProperties())
+				.flatMap(cfOperations -> Mono.justOrEmpty(req.getName())
+					.flatMap(appName -> cfOperations.applications().restart(
+						org.cloudfoundry.operations.applications.RestartApplicationRequest.builder()
+							.name(appName)
+							.build())
+						.doOnRequest(l -> logger.debug("Restarting application {}", appName))
+						.doOnSuccess(item -> logger.info("Successfully restarted application {}", appName))
+						.doOnError(error -> logger.error("Failed to restart application {}", appName)))));
+	}
+
+	@Override
+	public Mono<Void> restage(RestageApplicationRequest request) {
+		return Mono.justOrEmpty(request)
+			.flatMap(req -> operationsUtils.getOperations(req.getProperties())
+				.flatMap(cfOperations -> Mono.justOrEmpty(req.getName())
+					.flatMap(appName -> cfOperations.applications().restage(
+						org.cloudfoundry.operations.applications.RestageApplicationRequest.builder()
+							.name(appName)
+							.build())
+						.doOnRequest(l -> logger.debug("Restaging application {}", appName))
+						.doOnSuccess(item -> logger.info("Successfully restaged application {}", appName))
+						.doOnError(error -> logger.error("Failed to restage application {}", appName)))));
+	}
+}

--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryOperationsUtils.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryOperationsUtils.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016-2019 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.deployer.cloudfoundry;
+
+import java.util.Map;
+
+import org.cloudfoundry.operations.CloudFoundryOperations;
+import org.cloudfoundry.operations.DefaultCloudFoundryOperations;
+import reactor.core.publisher.Mono;
+
+import org.springframework.cloud.appbroker.deployer.DeploymentProperties;
+import org.springframework.util.CollectionUtils;
+
+public class CloudFoundryOperationsUtils {
+
+	private final CloudFoundryOperations operations;
+
+	public CloudFoundryOperationsUtils(CloudFoundryOperations operations) {
+		this.operations = operations;
+	}
+
+	public Mono<CloudFoundryOperations> getOperations(Map<String, String> properties) {
+		return Mono.defer(() -> {
+			if (!CollectionUtils.isEmpty(properties) && properties.containsKey(
+				DeploymentProperties.TARGET_PROPERTY_KEY)) {
+				return getOperationsForSpace(properties.get(DeploymentProperties.TARGET_PROPERTY_KEY));
+			}
+			return Mono.just(this.operations);
+		});
+	}
+
+	public Mono<CloudFoundryOperations> getOperationsForSpace(String space) {
+		return Mono.just(this.operations)
+			.cast(DefaultCloudFoundryOperations.class)
+			.map(cfOperations -> DefaultCloudFoundryOperations.builder()
+				.from(cfOperations)
+				.space(space)
+				.build());
+	}
+}

--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/test/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployerUpdateApplicationTest.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/test/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployerUpdateApplicationTest.java
@@ -60,6 +60,8 @@ import org.springframework.core.io.ResourceLoader;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -93,6 +95,9 @@ class CloudFoundryAppDeployerUpdateApplicationTest {
 	private CloudFoundryClient cloudFoundryClient;
 
 	@Mock
+	private CloudFoundryOperationsUtils operationsUtils;
+
+	@Mock
 	private ResourceLoader resourceLoader;
 
 	@BeforeEach
@@ -108,9 +113,11 @@ class CloudFoundryAppDeployerUpdateApplicationTest {
 		when(cloudFoundryClient.packages()).thenReturn(packages);
 		when(cloudFoundryClient.builds()).thenReturn(builds);
 		when(cloudFoundryClient.deploymentsV3()).thenReturn(deploymentsV3);
+		when(operationsUtils.getOperations(anyMap())).thenReturn(Mono.just(cloudFoundryOperations));
+		when(operationsUtils.getOperationsForSpace(anyString())).thenReturn(Mono.just(cloudFoundryOperations));
 
 		appDeployer = new CloudFoundryAppDeployer(deploymentProperties,
-			cloudFoundryOperations, cloudFoundryClient, targetProperties, resourceLoader);
+			cloudFoundryOperations, cloudFoundryClient, operationsUtils, targetProperties, resourceLoader);
 	}
 
 	@Test

--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/test/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppManagerTest.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/test/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppManagerTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2016-2019 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.deployer.cloudfoundry;
+
+import org.cloudfoundry.operations.CloudFoundryOperations;
+import org.cloudfoundry.operations.applications.Applications;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import org.springframework.cloud.appbroker.manager.RestageApplicationRequest;
+import org.springframework.cloud.appbroker.manager.RestartApplicationRequest;
+import org.springframework.cloud.appbroker.manager.StartApplicationRequest;
+import org.springframework.cloud.appbroker.manager.StopApplicationRequest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CloudFoundryAppManagerTest {
+
+	private CloudFoundryAppManager appManager;
+
+	@Mock
+	private Applications operationsApplications;
+
+	@Mock
+	private CloudFoundryOperations operations;
+
+	@Mock
+	private CloudFoundryOperationsUtils operationsUtils;
+
+	@BeforeEach
+	void setUp() {
+		this.appManager = new CloudFoundryAppManager(operationsUtils);
+	}
+
+	@Test
+	void startNullApplication() {
+		StepVerifier.create(appManager.start(null))
+			.verifyComplete();
+
+		verifyZeroInteractions(operationsApplications);
+		verifyNoMoreInteractions(operations);
+	}
+
+	@Test
+	void startApplication() {
+		setupStubs();
+
+		when(operationsApplications.start(any(org.cloudfoundry.operations.applications.StartApplicationRequest.class)))
+			.thenReturn(Mono.empty());
+
+		StartApplicationRequest request = StartApplicationRequest.builder()
+			.name("my-foo-app")
+			.build();
+
+		StepVerifier.create(appManager.start(request))
+			.verifyComplete();
+
+		verify(operationsApplications).start(argThat(req -> "my-foo-app".equals(req.getName())));
+		verifyNoMoreInteractions(operations);
+	}
+
+	@Test
+	void startApplicationWithEmptyName() {
+		when(operationsUtils.getOperations(anyMap())).thenReturn(Mono.just(operations));
+
+		StartApplicationRequest request = StartApplicationRequest.builder()
+			.build();
+
+		StepVerifier.create(appManager.start(request))
+			.verifyComplete();
+
+		verifyZeroInteractions(operationsApplications);
+		verifyNoMoreInteractions(operations);
+	}
+
+	@Test
+	void stopNullApplication() {
+		StepVerifier.create(appManager.stop(null))
+			.verifyComplete();
+
+		verifyZeroInteractions(operationsApplications);
+		verifyNoMoreInteractions(operations);
+	}
+
+	@Test
+	void stopApplication() {
+		setupStubs();
+
+		when(operationsApplications.stop(any(org.cloudfoundry.operations.applications.StopApplicationRequest.class)))
+			.thenReturn(Mono.empty());
+
+		StopApplicationRequest request = StopApplicationRequest.builder()
+			.name("my-foo-app")
+			.build();
+
+		StepVerifier.create(appManager.stop(request))
+			.verifyComplete();
+
+		verify(operationsApplications).stop(argThat(req -> "my-foo-app".equals(req.getName())));
+		verifyNoMoreInteractions(operations);
+	}
+
+	@Test
+	void stopApplicationWithEmptyName() {
+		when(operationsUtils.getOperations(anyMap())).thenReturn(Mono.just(operations));
+
+		StopApplicationRequest request = StopApplicationRequest.builder()
+			.build();
+
+		StepVerifier.create(appManager.stop(request))
+			.verifyComplete();
+
+		verifyZeroInteractions(operationsApplications);
+		verifyNoMoreInteractions(operations);
+	}
+
+	@Test
+	void restartNullApplication() {
+		StepVerifier.create(appManager.restart(null))
+			.verifyComplete();
+
+		verifyZeroInteractions(operationsApplications);
+		verifyNoMoreInteractions(operations);
+	}
+
+	@Test
+	void restartApplication() {
+		setupStubs();
+
+		when(operationsApplications.restart(any(org.cloudfoundry.operations.applications.RestartApplicationRequest.class)))
+			.thenReturn(Mono.empty());
+
+		RestartApplicationRequest request = RestartApplicationRequest.builder()
+			.name("my-foo-app")
+			.build();
+
+		StepVerifier.create(appManager.restart(request))
+			.verifyComplete();
+
+		verify(operationsApplications).restart(argThat(req -> "my-foo-app".equals(req.getName())));
+		verifyNoMoreInteractions(operations);
+	}
+
+	@Test
+	void restartApplicationWithEmptyName() {
+		when(operationsUtils.getOperations(anyMap())).thenReturn(Mono.just(operations));
+
+		RestartApplicationRequest request = RestartApplicationRequest.builder()
+			.build();
+
+		StepVerifier.create(appManager.restart(request))
+			.verifyComplete();
+
+		verifyZeroInteractions(operationsApplications);
+		verifyNoMoreInteractions(operations);
+	}
+
+	@Test
+	void restageNullApplication() {
+		StepVerifier.create(appManager.restage(null))
+			.verifyComplete();
+
+		verifyZeroInteractions(operationsApplications);
+		verifyNoMoreInteractions(operations);
+	}
+
+	@Test
+	void restageApplication() {
+		setupStubs();
+
+		when(operationsApplications.restage(any(org.cloudfoundry.operations.applications.RestageApplicationRequest.class)))
+			.thenReturn(Mono.empty());
+
+		RestageApplicationRequest request = RestageApplicationRequest.builder()
+			.name("my-foo-app")
+			.build();
+
+		StepVerifier.create(appManager.restage(request))
+			.verifyComplete();
+
+		verify(operationsApplications).restage(argThat(req -> "my-foo-app".equals(req.getName())));
+		verifyNoMoreInteractions(operations);
+	}
+
+	@Test
+	void restageApplicationWithEmptyName() {
+		when(operationsUtils.getOperations(anyMap())).thenReturn(Mono.just(operations));
+
+		RestageApplicationRequest request = RestageApplicationRequest.builder()
+			.build();
+
+		StepVerifier.create(appManager.restage(request))
+			.verifyComplete();
+
+		verifyZeroInteractions(operationsApplications);
+		verifyNoMoreInteractions(operations);
+	}
+
+	private void setupStubs() {
+		when(operations.applications()).thenReturn(operationsApplications);
+		when(operationsUtils.getOperations(anyMap())).thenReturn(Mono.just(operations));
+	}
+}

--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/test/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryOperationsUtilsTest.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/test/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryOperationsUtilsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016-2019 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.deployer.cloudfoundry;
+
+import java.util.Collections;
+
+import org.cloudfoundry.operations.CloudFoundryOperations;
+import org.cloudfoundry.operations.DefaultCloudFoundryOperations;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+
+import org.springframework.cloud.appbroker.deployer.DeploymentProperties;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CloudFoundryOperationsUtilsTest {
+
+	private CloudFoundryOperationsUtils operationsUtils;
+
+	private CloudFoundryOperations operations;
+
+	@BeforeEach
+	void setUp() {
+		this.operations = DefaultCloudFoundryOperations.builder().build();
+		this.operationsUtils = new CloudFoundryOperationsUtils(operations);
+	}
+
+	@Test
+	void getOperationsWithEmptyProperties() {
+		StepVerifier.create(operationsUtils.getOperations(Collections.emptyMap()))
+			.expectNext(operations)
+			.verifyComplete();
+	}
+
+	@Test
+	void getOperationsWithProperties() {
+		StepVerifier.create(operationsUtils.getOperations(Collections.singletonMap(DeploymentProperties.TARGET_PROPERTY_KEY, "foo-space1")))
+			.assertNext(ops -> {
+				String space = (String) ReflectionTestUtils.getField(ops, "space");
+				assertThat(space).isEqualTo("foo-space1");
+			})
+			.verifyComplete();
+	}
+
+	@Test
+	void getOperationsForSpace() {
+		StepVerifier.create(operationsUtils.getOperationsForSpace("foo-space2"))
+			.assertNext(ops -> {
+				String space = (String) ReflectionTestUtils.getField(ops, "space");
+				assertThat(space).isEqualTo("foo-space2");
+			})
+			.verifyComplete();
+	}
+}

--- a/spring-cloud-app-broker-deployer/build.gradle
+++ b/spring-cloud-app-broker-deployer/build.gradle
@@ -25,4 +25,7 @@ dependencyManagement {
 dependencies {
 	compile("org.springframework:spring-core")
 	compile("io.projectreactor:reactor-core")
+	testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+	testCompile("org.junit.jupiter:junit-jupiter-api")
+	testCompile("org.assertj:assertj-core")
 }

--- a/spring-cloud-app-broker-deployer/src/main/java/org/springframework/cloud/appbroker/deployer/AppDeployer.java
+++ b/spring-cloud-app-broker-deployer/src/main/java/org/springframework/cloud/appbroker/deployer/AppDeployer.java
@@ -32,6 +32,10 @@ public interface AppDeployer {
 		return Mono.empty();
 	}
 
+	default Mono<GetServiceInstanceResponse> getServiceInstance(GetServiceInstanceRequest request) {
+		return Mono.empty();
+	}
+
 	default Mono<CreateServiceInstanceResponse> createServiceInstance(CreateServiceInstanceRequest request) {
 		return Mono.empty();
 	}

--- a/spring-cloud-app-broker-deployer/src/main/java/org/springframework/cloud/appbroker/deployer/GetServiceInstanceRequest.java
+++ b/spring-cloud-app-broker-deployer/src/main/java/org/springframework/cloud/appbroker/deployer/GetServiceInstanceRequest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016-2019 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.deployer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.util.CollectionUtils;
+
+public class GetServiceInstanceRequest {
+
+	private final String name;
+
+	private final String serviceInstanceId;
+
+	private final Map<String, String> properties;
+
+	GetServiceInstanceRequest(String name, String serviceInstanceId, Map<String, String> properties) {
+		this.name = name;
+		this.serviceInstanceId = serviceInstanceId;
+		this.properties = properties;
+	}
+
+	public static GetServiceInstanceRequestBuilder builder() {
+		return new GetServiceInstanceRequestBuilder();
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public String getServiceInstanceId() {
+		return serviceInstanceId;
+	}
+
+	public Map<String, String> getProperties() {
+		return properties;
+	}
+
+	public static class GetServiceInstanceRequestBuilder {
+
+		private String name;
+
+		private String serviceInstanceId;
+
+		private final Map<String, String> properties = new HashMap<>();
+
+		GetServiceInstanceRequestBuilder() {
+		}
+
+		public GetServiceInstanceRequestBuilder name(String name) {
+			this.name = name;
+			return this;
+		}
+
+		public GetServiceInstanceRequestBuilder serviceInstanceId(String serviceInstanceId) {
+			this.serviceInstanceId = serviceInstanceId;
+			return this;
+		}
+
+		public GetServiceInstanceRequestBuilder properties(Map<String, String> properties) {
+			if (!CollectionUtils.isEmpty(properties)) {
+				this.properties.putAll(properties);
+			}
+			return this;
+		}
+
+		public GetServiceInstanceRequest build() {
+			return new GetServiceInstanceRequest(name, serviceInstanceId, properties);
+		}
+
+	}
+}

--- a/spring-cloud-app-broker-deployer/src/main/java/org/springframework/cloud/appbroker/deployer/GetServiceInstanceResponse.java
+++ b/spring-cloud-app-broker-deployer/src/main/java/org/springframework/cloud/appbroker/deployer/GetServiceInstanceResponse.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016-2019 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.deployer;
+
+public class GetServiceInstanceResponse {
+
+	private final String name;
+
+	private final String service;
+
+	private final String plan;
+
+	GetServiceInstanceResponse(String name, String service, String plan) {
+		this.name = name;
+		this.service = service;
+		this.plan = plan;
+	}
+
+	public static CreateServiceInstanceRequestBuilder builder() {
+		return new CreateServiceInstanceRequestBuilder();
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public String getService() {
+		return service;
+	}
+
+	public String getPlan() {
+		return plan;
+	}
+
+	public static class CreateServiceInstanceRequestBuilder {
+
+		private String name;
+
+		private String service;
+
+		private String plan;
+
+		CreateServiceInstanceRequestBuilder() {
+		}
+
+		public CreateServiceInstanceRequestBuilder name(String name) {
+			this.name = name;
+			return this;
+		}
+
+		public CreateServiceInstanceRequestBuilder service(String service) {
+			this.service = service;
+			return this;
+		}
+
+		public CreateServiceInstanceRequestBuilder plan(String plan) {
+			this.plan = plan;
+			return this;
+		}
+
+		public GetServiceInstanceResponse build() {
+			return new GetServiceInstanceResponse(name, service, plan);
+		}
+	}
+
+}

--- a/spring-cloud-app-broker-deployer/src/main/java/org/springframework/cloud/appbroker/manager/AppManager.java
+++ b/spring-cloud-app-broker-deployer/src/main/java/org/springframework/cloud/appbroker/manager/AppManager.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016-2019 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.manager;
+
+import reactor.core.publisher.Mono;
+
+public interface AppManager {
+
+	default Mono<Void> start(StartApplicationRequest request) {
+		return Mono.empty();
+	}
+
+	default Mono<Void> stop(StopApplicationRequest request) {
+		return Mono.empty();
+	}
+
+	default Mono<Void> restart(RestartApplicationRequest request) {
+		return Mono.empty();
+	}
+
+	default Mono<Void> restage(RestageApplicationRequest request) {
+		return Mono.empty();
+	}
+}

--- a/spring-cloud-app-broker-deployer/src/main/java/org/springframework/cloud/appbroker/manager/RestageApplicationRequest.java
+++ b/spring-cloud-app-broker-deployer/src/main/java/org/springframework/cloud/appbroker/manager/RestageApplicationRequest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016-2019 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.manager;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.util.CollectionUtils;
+
+public class RestageApplicationRequest {
+
+	private final String name;
+
+	private final Map<String, String> properties;
+
+	RestageApplicationRequest(String name, Map<String, String> properties) {
+		this.name = name;
+		this.properties = properties;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public Map<String, String> getProperties() {
+		return properties;
+	}
+
+	public static RestageApplicationRequestBuilder builder() {
+		return new RestageApplicationRequestBuilder();
+	}
+
+	public static class RestageApplicationRequestBuilder {
+
+		private String name;
+
+		private final Map<String, String> properties = new HashMap<>();
+
+		RestageApplicationRequestBuilder() {
+		}
+
+		public RestageApplicationRequestBuilder name(String name) {
+			this.name = name;
+			return this;
+		}
+
+		public RestageApplicationRequestBuilder properties(Map<String, String> properties) {
+			if (!CollectionUtils.isEmpty(properties)) {
+				this.properties.putAll(properties);
+			}
+			return this;
+		}
+
+		public RestageApplicationRequest build() {
+			return new RestageApplicationRequest(name, properties);
+		}
+
+	}
+}

--- a/spring-cloud-app-broker-deployer/src/main/java/org/springframework/cloud/appbroker/manager/RestartApplicationRequest.java
+++ b/spring-cloud-app-broker-deployer/src/main/java/org/springframework/cloud/appbroker/manager/RestartApplicationRequest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016-2019 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.manager;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.util.CollectionUtils;
+
+public class RestartApplicationRequest {
+
+	private final String name;
+
+	private final Map<String, String> properties;
+
+	RestartApplicationRequest(String name, Map<String, String> properties) {
+		this.name = name;
+		this.properties = properties;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public Map<String, String> getProperties() {
+		return properties;
+	}
+
+	public static RestartApplicationRequestBuilder builder() {
+		return new RestartApplicationRequestBuilder();
+	}
+
+	public static class RestartApplicationRequestBuilder {
+
+		private String name;
+
+		private final Map<String, String> properties = new HashMap<>();
+
+		RestartApplicationRequestBuilder() {
+		}
+
+		public RestartApplicationRequestBuilder name(String name) {
+			this.name = name;
+			return this;
+		}
+
+		public RestartApplicationRequestBuilder properties(Map<String, String> properties) {
+			if (!CollectionUtils.isEmpty(properties)) {
+				this.properties.putAll(properties);
+			}
+			return this;
+		}
+
+		public RestartApplicationRequest build() {
+			return new RestartApplicationRequest(name, properties);
+		}
+
+	}
+}

--- a/spring-cloud-app-broker-deployer/src/main/java/org/springframework/cloud/appbroker/manager/StartApplicationRequest.java
+++ b/spring-cloud-app-broker-deployer/src/main/java/org/springframework/cloud/appbroker/manager/StartApplicationRequest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016-2019 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.manager;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.util.CollectionUtils;
+
+public class StartApplicationRequest {
+
+	private final String name;
+
+	private final Map<String, String> properties;
+
+	StartApplicationRequest(String name, Map<String, String> properties) {
+		this.name = name;
+		this.properties = properties;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public Map<String, String> getProperties() {
+		return properties;
+	}
+
+	public static StartApplicationRequestBuilder builder() {
+		return new StartApplicationRequestBuilder();
+	}
+
+	public static class StartApplicationRequestBuilder {
+
+		private String name;
+
+		private final Map<String, String> properties = new HashMap<>();
+
+		StartApplicationRequestBuilder() {
+		}
+
+		public StartApplicationRequestBuilder name(String name) {
+			this.name = name;
+			return this;
+		}
+
+		public StartApplicationRequestBuilder properties(Map<String, String> properties) {
+			if (!CollectionUtils.isEmpty(properties)) {
+				this.properties.putAll(properties);
+			}
+			return this;
+		}
+
+		public StartApplicationRequest build() {
+			return new StartApplicationRequest(name, properties);
+		}
+
+	}
+}

--- a/spring-cloud-app-broker-deployer/src/main/java/org/springframework/cloud/appbroker/manager/StopApplicationRequest.java
+++ b/spring-cloud-app-broker-deployer/src/main/java/org/springframework/cloud/appbroker/manager/StopApplicationRequest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016-2019 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.manager;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.util.CollectionUtils;
+
+public class StopApplicationRequest {
+
+	private final String name;
+
+	private final Map<String, String> properties;
+
+	StopApplicationRequest(String name, Map<String, String> properties) {
+		this.name = name;
+		this.properties = properties;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public Map<String, String> getProperties() {
+		return properties;
+	}
+
+	public static StopApplicationRequestBuilder builder() {
+		return new StopApplicationRequestBuilder();
+	}
+
+	public static class StopApplicationRequestBuilder {
+
+		private String name;
+
+		private final Map<String, String> properties = new HashMap<>();
+
+		StopApplicationRequestBuilder() {
+		}
+
+		public StopApplicationRequestBuilder name(String name) {
+			this.name = name;
+			return this;
+		}
+
+		public StopApplicationRequestBuilder properties(Map<String, String> properties) {
+			if (!CollectionUtils.isEmpty(properties)) {
+				this.properties.putAll(properties);
+			}
+			return this;
+		}
+
+		public StopApplicationRequest build() {
+			return new StopApplicationRequest(name, properties);
+		}
+
+	}
+}

--- a/spring-cloud-app-broker-deployer/src/test/java/org/springframework/cloud/appbroker/deployer/GetServiceInstanceRequestTest.java
+++ b/spring-cloud-app-broker-deployer/src/test/java/org/springframework/cloud/appbroker/deployer/GetServiceInstanceRequestTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016-2019 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.deployer;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
+
+class GetServiceInstanceRequestTest {
+
+	@Test
+	void builderWithNoValues() {
+		GetServiceInstanceRequest request = GetServiceInstanceRequest.builder()
+			.build();
+		assertThat(request).isNotNull();
+		assertThat(request.getName()).isNull();
+		assertThat(request.getServiceInstanceId()).isNull();
+		assertThat(request.getProperties()).isEmpty();
+	}
+
+	@Test
+	void builderWithValues() {
+		GetServiceInstanceRequest request = GetServiceInstanceRequest.builder()
+			.name("foo-name")
+			.serviceInstanceId("foo-id")
+			.properties(Collections.singletonMap("foo", "bar"))
+			.build();
+		assertThat(request).isNotNull();
+		assertThat(request.getName()).isEqualTo("foo-name");
+		assertThat(request.getServiceInstanceId()).isEqualTo("foo-id");
+		assertThat(request.getProperties()).containsOnly(entry("foo", "bar"));
+	}
+
+	@Test
+	void builderAcceptsNullProperties() {
+		GetServiceInstanceRequest request = GetServiceInstanceRequest.builder()
+			.properties(null)
+			.build();
+		assertThat(request).isNotNull();
+		assertThat(request.getProperties()).isEmpty();
+	}
+
+	@Test
+	void builderAcceptsEmptyProperties() {
+		GetServiceInstanceRequest request = GetServiceInstanceRequest.builder()
+			.properties(Collections.emptyMap())
+			.build();
+		assertThat(request).isNotNull();
+		assertThat(request.getProperties()).isEmpty();
+	}
+
+}

--- a/spring-cloud-app-broker-deployer/src/test/java/org/springframework/cloud/appbroker/manager/RestageApplicationRequestTest.java
+++ b/spring-cloud-app-broker-deployer/src/test/java/org/springframework/cloud/appbroker/manager/RestageApplicationRequestTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016-2019 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.manager;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
+
+class RestageApplicationRequestTest {
+
+	@Test
+	void builderWithNoValues() {
+		RestageApplicationRequest request = RestageApplicationRequest.builder()
+			.build();
+		assertThat(request).isNotNull();
+		assertThat(request.getName()).isNull();
+		assertThat(request.getProperties()).isEmpty();
+	}
+
+	@Test
+	void builderWithValues() {
+		RestageApplicationRequest request = RestageApplicationRequest.builder()
+			.name("foo")
+			.properties(Collections.singletonMap("foo", "bar"))
+			.build();
+		assertThat(request).isNotNull();
+		assertThat(request.getName()).isEqualTo("foo");
+		assertThat(request.getProperties()).containsOnly(entry("foo", "bar"));
+	}
+
+	@Test
+	void builderAcceptsNullProperties() {
+		RestageApplicationRequest request = RestageApplicationRequest.builder()
+			.name("foo")
+			.properties(null)
+			.build();
+		assertThat(request).isNotNull();
+		assertThat(request.getName()).isEqualTo("foo");
+		assertThat(request.getProperties()).isEmpty();
+	}
+
+	@Test
+	void builderAcceptsEmptyProperties() {
+		RestageApplicationRequest request = RestageApplicationRequest.builder()
+			.name("foo")
+			.properties(Collections.emptyMap())
+			.build();
+		assertThat(request).isNotNull();
+		assertThat(request.getName()).isEqualTo("foo");
+		assertThat(request.getProperties()).isEmpty();
+	}
+}

--- a/spring-cloud-app-broker-deployer/src/test/java/org/springframework/cloud/appbroker/manager/RestartApplicationRequestTest.java
+++ b/spring-cloud-app-broker-deployer/src/test/java/org/springframework/cloud/appbroker/manager/RestartApplicationRequestTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016-2019 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.manager;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
+
+class RestartApplicationRequestTest {
+
+	@Test
+	void builderWithNoValues() {
+		RestartApplicationRequest request = RestartApplicationRequest.builder()
+			.build();
+		assertThat(request).isNotNull();
+		assertThat(request.getName()).isNull();
+		assertThat(request.getProperties()).isEmpty();
+	}
+
+	@Test
+	void builderWithValues() {
+		RestartApplicationRequest request = RestartApplicationRequest.builder()
+			.name("foo")
+			.properties(Collections.singletonMap("foo", "bar"))
+			.build();
+		assertThat(request).isNotNull();
+		assertThat(request.getName()).isEqualTo("foo");
+		assertThat(request.getProperties()).containsOnly(entry("foo", "bar"));
+	}
+
+	@Test
+	void builderAcceptsNullProperties() {
+		RestartApplicationRequest request = RestartApplicationRequest.builder()
+			.name("foo")
+			.properties(null)
+			.build();
+		assertThat(request).isNotNull();
+		assertThat(request.getName()).isEqualTo("foo");
+		assertThat(request.getProperties()).isEmpty();
+	}
+
+	@Test
+	void builderAcceptsEmptyProperties() {
+		RestartApplicationRequest request = RestartApplicationRequest.builder()
+			.name("foo")
+			.properties(Collections.emptyMap())
+			.build();
+		assertThat(request).isNotNull();
+		assertThat(request.getName()).isEqualTo("foo");
+		assertThat(request.getProperties()).isEmpty();
+	}
+}

--- a/spring-cloud-app-broker-deployer/src/test/java/org/springframework/cloud/appbroker/manager/StartApplicationRequestTest.java
+++ b/spring-cloud-app-broker-deployer/src/test/java/org/springframework/cloud/appbroker/manager/StartApplicationRequestTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016-2019 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.manager;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
+
+class StartApplicationRequestTest {
+
+	@Test
+	void builderWithNoValues() {
+		StartApplicationRequest request = StartApplicationRequest.builder()
+			.build();
+		assertThat(request).isNotNull();
+		assertThat(request.getName()).isNull();
+		assertThat(request.getProperties()).isEmpty();
+	}
+
+	@Test
+	void builderWithValues() {
+		StartApplicationRequest request = StartApplicationRequest.builder()
+			.name("foo")
+			.properties(Collections.singletonMap("foo", "bar"))
+			.build();
+		assertThat(request).isNotNull();
+		assertThat(request.getName()).isEqualTo("foo");
+		assertThat(request.getProperties()).containsOnly(entry("foo", "bar"));
+	}
+
+	@Test
+	void builderAcceptsNullProperties() {
+		StartApplicationRequest request = StartApplicationRequest.builder()
+			.name("foo")
+			.properties(null)
+			.build();
+		assertThat(request).isNotNull();
+		assertThat(request.getName()).isEqualTo("foo");
+		assertThat(request.getProperties()).isEmpty();
+	}
+
+	@Test
+	void builderAcceptsEmptyProperties() {
+		StartApplicationRequest request = StartApplicationRequest.builder()
+			.name("foo")
+			.properties(Collections.emptyMap())
+			.build();
+		assertThat(request).isNotNull();
+		assertThat(request.getName()).isEqualTo("foo");
+		assertThat(request.getProperties()).isEmpty();
+	}
+}

--- a/spring-cloud-app-broker-deployer/src/test/java/org/springframework/cloud/appbroker/manager/StopApplicationRequestTest.java
+++ b/spring-cloud-app-broker-deployer/src/test/java/org/springframework/cloud/appbroker/manager/StopApplicationRequestTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016-2019 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.manager;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
+
+class StopApplicationRequestTest {
+
+	@Test
+	void builderWithNoValues() {
+		StopApplicationRequest request = StopApplicationRequest.builder()
+			.build();
+		assertThat(request).isNotNull();
+		assertThat(request.getName()).isNull();
+		assertThat(request.getProperties()).isEmpty();
+	}
+
+	@Test
+	void builderWithValues() {
+		StopApplicationRequest request = StopApplicationRequest.builder()
+			.name("foo")
+			.properties(Collections.singletonMap("foo", "bar"))
+			.build();
+		assertThat(request).isNotNull();
+		assertThat(request.getName()).isEqualTo("foo");
+		assertThat(request.getProperties()).containsOnly(entry("foo", "bar"));
+	}
+
+	@Test
+	void builderAcceptsNullProperties() {
+		StopApplicationRequest request = StopApplicationRequest.builder()
+			.name("foo")
+			.properties(null)
+			.build();
+		assertThat(request).isNotNull();
+		assertThat(request.getName()).isEqualTo("foo");
+		assertThat(request.getProperties()).isEmpty();
+	}
+
+	@Test
+	void builderAcceptsEmptyProperties() {
+		StopApplicationRequest request = StopApplicationRequest.builder()
+			.name("foo")
+			.properties(Collections.emptyMap())
+			.build();
+		assertThat(request).isNotNull();
+		assertThat(request.getName()).isEqualTo("foo");
+		assertThat(request.getProperties()).isEmpty();
+	}
+}


### PR DESCRIPTION
This commit adds support to stop, start, restart, and restage the backing
applications associated with a deployed service instance. The management
functions are available from the new `BackingAppManagementService`.

Resolves #118