### PR TITLE
URL Cleanup

### DIFF
--- a/ci/config/pmdRuleSet.xml
+++ b/ci/config/pmdRuleSet.xml
@@ -2,7 +2,7 @@
 <ruleset name="Custom ruleset"
 		 xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+		 xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
 
 	<rule ref="rulesets/java/basic.xml"/>
 	<rule ref="rulesets/java/braces.xml"/>

--- a/ci/config/pmdTestRuleSet.xml
+++ b/ci/config/pmdTestRuleSet.xml
@@ -18,7 +18,7 @@
 <ruleset name="Custom ruleset"
 		 xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+		 xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
 
 	<rule ref="rulesets/java/basic.xml"/>
 	<rule ref="rulesets/java/braces.xml">


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://pmd.sourceforge.net/ruleset_2_0_0.xsd (301) with 2 occurrences migrated to:  
  https://pmd.sourceforge.io/ruleset_2_0_0.xsd ([https](https://pmd.sourceforge.net/ruleset_2_0_0.xsd) result AnnotatedConnectException).

# Ignored
These URLs were intentionally ignored.

* http://pmd.sourceforge.net/ruleset/2.0.0 with 4 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 2 occurrences