### PR TITLE
Do not fail delete operation if backing apps or services are missing

### DIFF
--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/DeployerClient.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/DeployerClient.java
@@ -83,6 +83,9 @@ public class DeployerClient {
 			.doOnSuccess(response -> log.debug("Finished undeploying application {}", backingApplication))
 			.doOnError(exception -> log.error("Error undeploying application {} with error '{}'",
 				backingApplication, exception.getMessage()))
+			.onErrorReturn(UndeployApplicationResponse.builder()
+				.name(backingApplication.getName())
+				.build())
 			.map(UndeployApplicationResponse::getName);
 	}
 
@@ -129,11 +132,13 @@ public class DeployerClient {
 					.serviceInstanceName(backingService.getServiceInstanceName())
 					.properties(backingService.getProperties())
 					.build())
-
 			.doOnRequest(l -> log.debug("Deleting backing service {}", backingService.getName()))
 			.doOnSuccess(response -> log.debug("Finished deleting backing service {}", backingService.getName()))
 			.doOnError(exception -> log.error("Error deleting backing service {} with error '{}'",
 				backingService.getName(), exception.getMessage()))
+			.onErrorReturn(DeleteServiceInstanceResponse.builder()
+				.name(backingService.getServiceInstanceName())
+				.build())
 			.map(DeleteServiceInstanceResponse::getName);
 	}
 }

--- a/spring-cloud-app-broker-integration-tests/src/test/java/org.springframework.cloud.appbroker/integration/DeleteInstanceComponentTest.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org.springframework.cloud.appbroker/integration/DeleteInstanceComponentTest.java
@@ -102,6 +102,6 @@ class DeleteInstanceComponentTest extends WiremockComponentTest {
 			.body("state", is(equalTo(OperationState.IN_PROGRESS.toString())));
 
 		String state = brokerFixture.waitForAsyncOperationComplete("instance-id");
-		assertThat(state).isEqualTo(OperationState.FAILED.toString());
+		assertThat(state).isEqualTo(OperationState.SUCCEEDED.toString());
 	}
 }


### PR DESCRIPTION
If backing apps or services are missing, then the error is logged and the
app name or service instance name is returned as if the service was deleted
as expected.

Resolves #208