### PR TITLE
Make StateRepository beans conditional

### DIFF
--- a/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfiguration.java
+++ b/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfiguration.java
@@ -104,11 +104,13 @@ public class AppBrokerAutoConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnMissingBean(ServiceInstanceStateRepository.class)
 	public ServiceInstanceStateRepository serviceInstanceStateRepository() {
 		return new InMemoryServiceInstanceStateRepository();
 	}
 
 	@Bean
+	@ConditionalOnMissingBean(ServiceInstanceBindingStateRepository.class)
 	public ServiceInstanceBindingStateRepository serviceInstanceBindingStateRepository() {
 		return new InMemoryServiceInstanceBindingStateRepository();
 	}

--- a/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfigurationTest.java
+++ b/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfigurationTest.java
@@ -137,6 +137,34 @@ class AppBrokerAutoConfigurationTest {
 			});
 	}
 
+	@Test
+	void serviceInstanceStateRepositoryIsNotCreatedIfProvided() {
+		configuredContext()
+			.withUserConfiguration(CustomStateRepositoriesConfiguration.class)
+			.run(context -> {
+				assertBeansCreated(context);
+
+				assertThat(context)
+					.hasSingleBean(ServiceInstanceStateRepository.class)
+					.getBean(ServiceInstanceStateRepository.class)
+					.isExactlyInstanceOf(TestServiceInstanceStateRepository.class);
+			});
+	}
+
+	@Test
+	void serviceInstanceBindingStateRepositoryIsNotCreatedIfProvided() {
+		configuredContext()
+			.withUserConfiguration(CustomStateRepositoriesConfiguration.class)
+			.run(context -> {
+				assertBeansCreated(context);
+
+				assertThat(context)
+					.hasSingleBean(ServiceInstanceBindingStateRepository.class)
+					.getBean(ServiceInstanceBindingStateRepository.class)
+					.isExactlyInstanceOf(TestServiceInstanceBindingStateRepository.class);
+			});
+	}
+
 	private ApplicationContextRunner configuredContext() {
 		return this.contextRunner
 			.withPropertyValues(
@@ -240,6 +268,23 @@ class AppBrokerAutoConfigurationTest {
 		}
 	}
 
+	@Configuration
+	public static class CustomStateRepositoriesConfiguration {
+		@Bean
+		public ServiceInstanceStateRepository serviceInstanceStateRepository() {
+			return new TestServiceInstanceStateRepository();
+		}
+
+		@Bean
+		public ServiceInstanceBindingStateRepository serviceInstanceBindingStateRepository() {
+			return new TestServiceInstanceBindingStateRepository();
+		}
+	}
+
 	private static class TestServiceInstanceBindingService implements ServiceInstanceBindingService {
 	}
+
+	private static class TestServiceInstanceStateRepository implements ServiceInstanceStateRepository {}
+
+	private static class TestServiceInstanceBindingStateRepository implements ServiceInstanceBindingStateRepository {}
 }


### PR DESCRIPTION
Making `ServiceInstanceStateRepository` and
`ServiceInstanceBindingStateRepository` both `@ConditionalOnMissingBean`
allows App Broker consumers to easily override the default in-memory
implementation with their own.