### PR TITLE
Dynamically add space developer role for non-admin clients

### DIFF
--- a/spring-cloud-app-broker-acceptance-tests/README.adoc
+++ b/spring-cloud-app-broker-acceptance-tests/README.adoc
@@ -16,14 +16,8 @@ The tests require the following properties to be set:
 * `spring.cloud.appbroker.acceptance-test.cloudfoundry.default-org` - The CF organization where the tests are going to run.
 * `spring.cloud.appbroker.acceptance-test.cloudfoundry.default-space` - The CF space where the tests are going to run.
 * `spring.cloud.appbroker.acceptance-test.cloudfoundry.skip-ssl-validation` - If SSL validation should be skipped.
-
-To authenticate to the target CF with a user account, set the following properties:
-
 * `spring.cloud.appbroker.acceptance-test.cloudfoundry.username` - The CF API username.
 * `spring.cloud.appbroker.acceptance-test.cloudfoundry.password` - The CF API password.
-
-To authenticate to the target CF with an OAuth2 client in UAA, set the following properties:
-
 * `spring.cloud.appbroker.acceptance-test.cloudfoundry.client-id` - The CF API OAuth2 client ID.
 * `spring.cloud.appbroker.acceptance-test.cloudfoundry.client-secret` - The CF API OAuth2 client secret.
 

--- a/spring-cloud-app-broker-integration-tests/src/test/java/org.springframework.cloud.appbroker/integration/CreateInstanceWithSpacePerServiceInstanceTargetComponentTest.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org.springframework.cloud.appbroker/integration/CreateInstanceWithSpacePerServiceInstanceTargetComponentTest.java
@@ -63,8 +63,8 @@ class CreateInstanceWithSpacePerServiceInstanceTargetComponentTest extends Wirem
 	void pushAppWithServicesInSpace() {
 		String serviceInstanceId = "instance-id";
 
-		cloudControllerFixture.stubSpaceDoesNotExist(serviceInstanceId);
 		cloudControllerFixture.stubCreateSpace(serviceInstanceId);
+		cloudControllerFixture.stubAssociatePermissions(serviceInstanceId);
 		cloudControllerFixture.stubPushAppWithHost(APP_NAME, APP_NAME + "-" + serviceInstanceId);
 
 		// given services are available in the marketplace

--- a/spring-cloud-app-broker-integration-tests/src/test/java/org.springframework.cloud.appbroker/integration/fixtures/CloudControllerStubFixture.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org.springframework.cloud.appbroker/integration/fixtures/CloudControllerStubFixture.java
@@ -142,13 +142,6 @@ public class CloudControllerStubFixture extends WiremockStubFixture {
 					replace("@org-guid", TEST_ORG_GUID)))));
 	}
 
-	public void stubSpaceDoesNotExist(final String spaceName) {
-		stubFor(get(urlPathEqualTo("/v2/organizations/" + TEST_ORG_GUID + "/spaces"))
-			.withQueryParam("q", equalTo("name:" + spaceName))
-			.willReturn(ok()
-				.withBody(cc("empty-query-results"))));
-	}
-
 	public void stubCreateSpace(final String spaceName) {
 		stubFor(post(urlPathEqualTo("/v2/spaces"))
 			.withRequestBody(matchingJsonPath("$.[?(@.name == '" + spaceName + "')]"))
@@ -510,6 +503,26 @@ public class CloudControllerStubFixture extends WiremockStubFixture {
 		stubFor(get(urlPathEqualTo("/v2/apps/" + appGuid(appName) + "/service_bindings"))
 			.willReturn(ok()
 				.withBody(cc("empty-query-results"))));
+	}
+
+	public void stubAssociatePermissions(final String spaceName) {
+		stubFor(get(urlPathEqualTo("/v2/config/feature_flags/set_roles_by_username"))
+			.willReturn(ok()
+				.withBody(cc("get-feature-flag-roles"))));
+		stubSpaceExists(spaceName);
+
+		stubFor(put(urlPathEqualTo("/v2/organizations/" + TEST_ORG_GUID + "/users"))
+			.willReturn(ok()));
+	}
+
+	private void stubSpaceExists(final String spaceName) {
+		stubFor(get(urlPathEqualTo("/v2/organizations/" + TEST_ORG_GUID + "/spaces"))
+			.withQueryParam("q", equalTo("name:" + spaceName))
+			.willReturn(ok()
+				.withBody(cc("list-spaces",
+					replace("@org-guid", TEST_ORG_GUID),
+					replace("@space-guid", TEST_SPACE_GUID),
+					replace("@name", spaceName)))));
 	}
 
 	private String cc(String fileRoot, StringReplacementPair... replacements) {

--- a/spring-cloud-app-broker-integration-tests/src/test/resources/responses/cloudcontroller/get-feature-flag-roles.json
+++ b/spring-cloud-app-broker-integration-tests/src/test/resources/responses/cloudcontroller/get-feature-flag-roles.json
@@ -1,0 +1,6 @@
+{
+	"name": "set_roles_by_username",
+	"enabled": true,
+	"error_message": null,
+	"url": "/v2/config/feature_flags/set_roles_by_username"
+}


### PR DESCRIPTION
When using the space per service instance strategy, currently the OAuth
client requires `cloud_controller.admin` privileges to deploy apps and
services to a new space. This commit adds support for dynamically granting
the space developer role to a client which has the org manager role but not
admin privileges.

Resolves #203