### PR TITLE
Adding support for service instance upgrade

### DIFF
--- a/spring-cloud-app-broker-integration-tests/src/test/java/org.springframework.cloud.appbroker/integration/UpdateInstanceWithUpgradeComponentTest.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org.springframework.cloud.appbroker/integration/UpdateInstanceWithUpgradeComponentTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.integration;
+
+import java.util.HashMap;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.appbroker.integration.fixtures.CloudControllerStubFixture;
+import org.springframework.cloud.appbroker.integration.fixtures.OpenServiceBrokerApiFixture;
+import org.springframework.cloud.servicebroker.model.instance.OperationState;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.TestPropertySource;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.cloud.appbroker.integration.UpdateInstanceWithUpgradeComponentTest.APP_NAME_1;
+
+@TestPropertySource(properties = {
+		"spring.cloud.appbroker.services[0].service-name=example",
+		"spring.cloud.appbroker.services[0].plan-name=standard",
+		"spring.cloud.appbroker.services[0].apps[0].path=classpath:demo.jar",
+		"spring.cloud.appbroker.services[0].apps[0].name=" + APP_NAME_1,
+		"spring.cloud.appbroker.services[0].apps[0].parameters-transformers[0].name=PropertyMapping",
+		"spring.cloud.appbroker.services[0].apps[0].parameters-transformers[0].args.include=upgrade"
+})
+class UpdateInstanceWithUpgradeComponentTest extends WiremockComponentTest {
+
+	static final String APP_NAME_1 = "upgrade-first-app";
+
+	@Autowired
+	private OpenServiceBrokerApiFixture brokerFixture;
+
+	@Autowired
+	private CloudControllerStubFixture cloudControllerFixture;
+
+	@Test
+	void updateAppsWhenTheyExist() {
+		cloudControllerFixture.stubAppExists(APP_NAME_1);
+		cloudControllerFixture.stubUpdateAppWithUpgrade(APP_NAME_1);
+
+		// when a service instance is updated with upgrade flag
+		HashMap<String, Object> upgradeParameter = new HashMap<>();
+		upgradeParameter.put("upgrade", true);
+		given(brokerFixture.serviceInstanceRequest(upgradeParameter))
+				.when()
+				.patch(brokerFixture.createServiceInstanceUrl(), "instance-id")
+				.then()
+				.statusCode(HttpStatus.ACCEPTED.value());
+
+		// when the "last_operation" API is polled
+		given(brokerFixture.serviceInstanceRequest())
+				.when()
+				.get(brokerFixture.getLastInstanceOperationUrl(), "instance-id")
+				.then()
+				.statusCode(HttpStatus.OK.value())
+				.body("state", is(equalTo(OperationState.IN_PROGRESS.toString())));
+
+		String state = brokerFixture.waitForAsyncOperationComplete("instance-id");
+		assertThat(state).isEqualTo(OperationState.SUCCEEDED.toString());
+	}
+}

--- a/spring-cloud-app-broker-integration-tests/src/test/java/org.springframework.cloud.appbroker/integration/fixtures/CloudControllerStubFixture.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org.springframework.cloud.appbroker/integration/fixtures/CloudControllerStubFixture.java
@@ -216,9 +216,16 @@ public class CloudControllerStubFixture extends WiremockStubFixture {
 		stubAppAfterCreation(appName, host);
 	}
 
-	public void stubUpdateApp(final String appName) {
+	public void stubUpdateAppWithUpgrade(final String appName) {
 		stubUpdateEnvironment(appName);
 		stubCreatePackage(appName);
+		stubCreateBuild(appName);
+		stubCreateDeployment(appName);
+	}
+
+	public void stubUpdateApp(final String appName) {
+		stubUpdateEnvironment(appName);
+		stubGetPackage(appName);
 		stubCreateBuild(appName);
 		stubCreateDeployment(appName);
 	}
@@ -259,6 +266,14 @@ public class CloudControllerStubFixture extends WiremockStubFixture {
 				.withBody(cc("get-package-READY",
 					replace("@guid", packageGuid(appName)),
 					replace("@app-guid", appGuid(appName))))));
+	}
+
+	private void stubGetPackage(String appName) {
+		stubFor(get(urlPathEqualTo("/v3/apps/" + appGuid(appName) + "/packages"))
+				.withQueryParam("states", equalTo("READY"))
+				.willReturn(ok()
+						.withBody(cc("get-packages-READY",
+								replace("@package-guid", packageGuid(appName))))));
 	}
 
 	private void stubCreateBuild(String appName) {

--- a/spring-cloud-app-broker-integration-tests/src/test/resources/responses/cloudcontroller/get-packages-READY.json
+++ b/spring-cloud-app-broker-integration-tests/src/test/resources/responses/cloudcontroller/get-packages-READY.json
@@ -1,0 +1,84 @@
+{
+	"pagination": {
+		"total_results": 2,
+		"total_pages": 1,
+		"first": {
+			"href": "https://api.example.org/v3/apps/@guid/packages?page=1&per_page=50&states=READY"
+		},
+		"last": {
+			"href": "https://api.example.org/v3/apps/@guid/packages?page=1&per_page=50&states=READY"
+		},
+		"next": null,
+		"previous": null
+	},
+	"resources": [
+		{
+			"guid": "@package-guid",
+			"type": "bits",
+			"data": {
+				"error": null,
+				"checksum": {
+					"type": "sha256",
+					"value": "f0b54c3487602705ff0d25d69d629a6d46c7314496897e651caca6d99c04710c"
+				}
+			},
+			"state": "READY",
+			"created_at": "2019-07-05T10:32:56Z",
+			"updated_at": "2019-07-05T10:33:02Z",
+			"links": {
+				"self": {
+					"href": "https://api.example.org/v3/packages/07b68615-4d07-4322-975e-2f1e8d001a09"
+				},
+				"upload": {
+					"href": "https://api.example.org/v3/packages/07b68615-4d07-4322-975e-2f1e8d001a09/upload",
+					"method": "POST"
+				},
+				"download": {
+					"href": "https://api.example.org/v3/packages/07b68615-4d07-4322-975e-2f1e8d001a09/download",
+					"method": "GET"
+				},
+				"app": {
+					"href": "https://api.example.org/v3/apps/@guid"
+				}
+			},
+			"metadata": {
+				"labels": {},
+				"annotations": {}
+			}
+		},
+		{
+			"guid": "@package-guid",
+			"type": "bits",
+			"data": {
+				"error": null,
+				"checksum": {
+					"type": "sha256",
+					"value": "f03e4ab0bda4f3012e85e66f7dfb8c311d79a71e182173a5dc41a3fe1a961a92"
+				}
+			},
+			"state": "READY",
+			"created_at": "2019-07-05T10:37:38Z",
+			"updated_at": "2019-07-05T10:37:47Z",
+			"links": {
+				"self": {
+					"href": "https://api.example.org/v3/packages/989e5b16-4ce0-4005-87cb-19203dccfe3f"
+				},
+				"upload": {
+					"href": "https://api.example.org/v3/packages/989e5b16-4ce0-4005-87cb-19203dccfe3f/upload",
+					"method": "POST"
+				},
+				"download": {
+					"href": "https://api.example.org/v3/packages/989e5b16-4ce0-4005-87cb-19203dccfe3f/download",
+					"method": "GET"
+				},
+				"app": {
+					"href": "https://api.example.org/v3/apps/@guid"
+				}
+			},
+			"metadata": {
+				"labels": {},
+				"annotations": {}
+			}
+		}
+	]
+}


### PR DESCRIPTION
Before every update-service call would upgrade the backing application.
This changes will only create a new application package when the `upgrade` flag is provided as an `-c` parameter.