### PR TITLE
Fix concurrency issue with InMemory state repositories

### DIFF
--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/state/InMemoryServiceInstanceBindingStateRepository.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/state/InMemoryServiceInstanceBindingStateRepository.java
@@ -18,9 +18,9 @@ package org.springframework.cloud.appbroker.state;
 
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 
 import reactor.core.publisher.Mono;
 
@@ -31,7 +31,7 @@ import org.springframework.cloud.servicebroker.model.instance.OperationState;
  */
 public class InMemoryServiceInstanceBindingStateRepository implements ServiceInstanceBindingStateRepository {
 
-	private volatile Map<BindingKey, ServiceInstanceState> states = new HashMap<>();
+	private final Map<BindingKey, ServiceInstanceState> states = new ConcurrentHashMap<>();
 
 	@Override
 	public Mono<ServiceInstanceState> saveState(String serviceInstanceId, String bindingId, OperationState state, String description) {

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/state/InMemoryServiceInstanceStateRepository.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/state/InMemoryServiceInstanceStateRepository.java
@@ -18,8 +18,8 @@ package org.springframework.cloud.appbroker.state;
 
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import reactor.core.publisher.Mono;
 
@@ -27,7 +27,7 @@ import org.springframework.cloud.servicebroker.model.instance.OperationState;
 
 public class InMemoryServiceInstanceStateRepository implements ServiceInstanceStateRepository {
 
-	private volatile Map<String, ServiceInstanceState> states = new HashMap<>();
+	private final Map<String, ServiceInstanceState> states = new ConcurrentHashMap<>();
 
 	@Override
 	public Mono<ServiceInstanceState> saveState(String serviceInstanceId, OperationState state, String description) {

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/state/InMemoryServiceInstanceStateRepositoryTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/state/InMemoryServiceInstanceStateRepositoryTest.java
@@ -20,6 +20,8 @@ import java.util.Calendar;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
 import org.springframework.cloud.servicebroker.model.instance.OperationState;
@@ -126,5 +128,19 @@ class InMemoryServiceInstanceStateRepositoryTest {
 		StepVerifier.create(stateRepository.removeState("foo"))
 			.expectError(IllegalArgumentException.class)
 			.verify();
+	}
+
+	@Test
+	void ensureConcurrency() {
+		StepVerifier.create(
+			Flux.range(0, 100_000)
+				.parallel(25)
+				.runOn(Schedulers.newParallel("parallel-test", 25))
+				.flatMap(value ->
+					stateRepository
+						.saveState("foo" + value, OperationState.IN_PROGRESS, "bar")
+						.then(stateRepository.removeState("foo" + value))))
+			.expectNextCount(100_000)
+			.verifyComplete();
 	}
 }


### PR DESCRIPTION
Resolves #254

The added tests are flaky with the old implementation and may result in the following stacktrace during execution, which is the result of a concurrent modification of the non-threadsafe HashMap:
```
java.lang.AssertionError: expectation "expectNextCount(100000)" failed (expected: count = 100000; actual: counted = 516; signal: onError(java.lang.ClassCastException: class java.util.HashMap$Node cannot be cast to class java.util.HashMap$TreeNode (java.util.HashMap$Node and java.util.HashMap$TreeNode are in module java.base of loader 'bootstrap')))

	at reactor.test.ErrorFormatter.assertionError(ErrorFormatter.java:105)
	at reactor.test.ErrorFormatter.failPrefix(ErrorFormatter.java:94)
	at reactor.test.ErrorFormatter.fail(ErrorFormatter.java:64)
	at reactor.test.ErrorFormatter.failOptional(ErrorFormatter.java:79)
	at reactor.test.DefaultStepVerifierBuilder$DefaultVerifySubscriber.checkCountMismatch(DefaultStepVerifierBuilder.java:1258)
	at reactor.test.DefaultStepVerifierBuilder$DefaultVerifySubscriber.onSignalCount(DefaultStepVerifierBuilder.java:1489)
	at reactor.test.DefaultStepVerifierBuilder$DefaultVerifySubscriber.onExpectation(DefaultStepVerifierBuilder.java:1341)
	at reactor.test.DefaultStepVerifierBuilder$DefaultVerifySubscriber.onError(DefaultStepVerifierBuilder.java:1030)
	at reactor.core.publisher.FluxHide$SuppressFuseableSubscriber.onError(FluxHide.java:132)
	at reactor.core.publisher.ParallelMergeSequential$MergeSequentialMain.drainLoop(ParallelMergeSequential.java:259)
	at reactor.core.publisher.ParallelMergeSequential$MergeSequentialMain.onNext(ParallelMergeSequential.java:209)
	at reactor.core.publisher.ParallelMergeSequential$MergeSequentialInner.onNext(ParallelMergeSequential.java:397)
	at reactor.core.publisher.FluxFlatMap$FlatMapMain.drainLoop(FluxFlatMap.java:664)
	at reactor.core.publisher.FluxFlatMap$FlatMapMain.drain(FluxFlatMap.java:540)
	at reactor.core.publisher.FluxFlatMap$FlatMapInner.onNext(FluxFlatMap.java:940)
	at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1490)
	at reactor.core.publisher.MonoIgnoreThen$ThenIgnoreMain.drain(MonoIgnoreThen.java:147)
	at reactor.core.publisher.MonoIgnoreThen.subscribe(MonoIgnoreThen.java:56)
	at reactor.core.publisher.Mono.subscribe(Mono.java:3710)
	at reactor.core.publisher.FluxFlatMap.trySubscribeScalarMap(FluxFlatMap.java:169)
	at reactor.core.publisher.MonoFlatMap.subscribe(MonoFlatMap.java:53)
	at reactor.core.publisher.Mono.subscribe(Mono.java:3710)
	at reactor.core.publisher.FluxFlatMap$FlatMapMain.onNext(FluxFlatMap.java:389)
	at reactor.core.publisher.FluxPublishOn$PublishOnSubscriber.runAsync(FluxPublishOn.java:398)
	at reactor.core.publisher.FluxPublishOn$PublishOnSubscriber.run(FluxPublishOn.java:484)
	at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:84)
	at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:37)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
	Suppressed: java.lang.ClassCastException: class java.util.HashMap$Node cannot be cast to class java.util.HashMap$TreeNode (java.util.HashMap$Node and java.util.HashMap$TreeNode are in module java.base of loader 'bootstrap')
		at java.base/java.util.HashMap$TreeNode.moveRootToFront(HashMap.java:1882)
		at java.base/java.util.HashMap$TreeNode.treeify(HashMap.java:1998)
		at java.base/java.util.HashMap.treeifyBin(HashMap.java:767)
		at java.base/java.util.HashMap.putVal(HashMap.java:639)
		at java.base/java.util.HashMap.put(HashMap.java:607)
		at org.springframework.cloud.appbroker.state.InMemoryServiceInstanceStateRepository.lambda$saveState$0(InMemoryServiceInstanceStateRepository.java:36)
		at reactor.core.publisher.MonoCallable.call(MonoCallable.java:91)
		at reactor.core.publisher.MonoIgnoreThen$ThenIgnoreMain.drain(MonoIgnoreThen.java:160)
		... 15 more
```