### PR TITLE
Fix blocking calls to workflow layers ...

### DIFF
--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/service/WorkflowServiceInstanceBindingService.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/service/WorkflowServiceInstanceBindingService.java
@@ -80,7 +80,6 @@ public class WorkflowServiceInstanceBindingService implements ServiceInstanceBin
 	@Override
 	public Mono<CreateServiceInstanceBindingResponse> createServiceInstanceBinding(CreateServiceInstanceBindingRequest request) {
 		return invokeCreateResponseBuilders(request)
-			.publishOn(Schedulers.parallel())
 			.doOnNext(response -> create(request, response)
 				.subscribe());
 	}
@@ -133,6 +132,7 @@ public class WorkflowServiceInstanceBindingService implements ServiceInstanceBin
 							  CreateServiceInstanceBindingResponse response) {
 		return stateRepository.saveState(request.getServiceInstanceId(), request.getBindingId(),
 			OperationState.IN_PROGRESS, "create service instance binding started")
+			.publishOn(Schedulers.parallel())
 			.thenMany(invokeCreateWorkflows(request, response)
 				.doOnRequest(l -> log.debug("Creating service instance binding {}", request))
 				.doOnComplete(() -> log.debug("Finished creating service instance binding {}", request))
@@ -168,7 +168,6 @@ public class WorkflowServiceInstanceBindingService implements ServiceInstanceBin
 	@Override
 	public Mono<DeleteServiceInstanceBindingResponse> deleteServiceInstanceBinding(DeleteServiceInstanceBindingRequest request) {
 		return invokeDeleteResponseBuilders(request)
-			.publishOn(Schedulers.parallel())
 			.doOnNext(response -> delete(request, response)
 				.subscribe());
 	}
@@ -189,6 +188,7 @@ public class WorkflowServiceInstanceBindingService implements ServiceInstanceBin
 							  DeleteServiceInstanceBindingResponse response) {
 		return stateRepository.saveState(request.getServiceInstanceId(), request.getBindingId(),
 			OperationState.IN_PROGRESS, "delete service instance binding started")
+			.publishOn(Schedulers.parallel())
 			.thenMany(invokeDeleteWorkflows(request, response)
 				.doOnRequest(l -> log.debug("Deleting service instance binding {}", request))
 				.doOnComplete(() -> log.debug("Finished deleting service instance binding {}", request))

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/service/WorkflowServiceInstanceService.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/service/WorkflowServiceInstanceService.java
@@ -76,7 +76,6 @@ public class WorkflowServiceInstanceService implements ServiceInstanceService {
 	@Override
 	public Mono<CreateServiceInstanceResponse> createServiceInstance(CreateServiceInstanceRequest request) {
 		return invokeCreateResponseBuilders(request)
-			.publishOn(Schedulers.parallel())
 			.doOnNext(response -> create(request, response)
 				.subscribe());
 	}
@@ -97,6 +96,7 @@ public class WorkflowServiceInstanceService implements ServiceInstanceService {
 		return stateRepository.saveState(request.getServiceInstanceId(),
 			OperationState.IN_PROGRESS,
 			"create service instance started")
+			.publishOn(Schedulers.parallel())
 			.thenMany(invokeCreateWorkflows(request, response)
 				.doOnRequest(l -> log.debug("Creating service instance {}", request))
 				.doOnComplete(() -> log.debug("Finished creating service instance {}", request))
@@ -120,7 +120,6 @@ public class WorkflowServiceInstanceService implements ServiceInstanceService {
 	@Override
 	public Mono<DeleteServiceInstanceResponse> deleteServiceInstance(DeleteServiceInstanceRequest request) {
 		return invokeDeleteResponseBuilders(request)
-			.publishOn(Schedulers.parallel())
 			.doOnNext(response -> delete(request, response)
 				.subscribe());
 	}
@@ -140,6 +139,7 @@ public class WorkflowServiceInstanceService implements ServiceInstanceService {
 	private Mono<Void> delete(DeleteServiceInstanceRequest request, DeleteServiceInstanceResponse response) {
 		return stateRepository.saveState(request.getServiceInstanceId(),
 			OperationState.IN_PROGRESS, "delete service instance started")
+			.publishOn(Schedulers.parallel())
 			.thenMany(invokeDeleteWorkflows(request, response)
 				.doOnRequest(l -> log.debug("Deleting service instance {}", request))
 				.doOnComplete(() -> log.debug("Finished deleting service instance {}", request))
@@ -163,7 +163,6 @@ public class WorkflowServiceInstanceService implements ServiceInstanceService {
 	@Override
 	public Mono<UpdateServiceInstanceResponse> updateServiceInstance(UpdateServiceInstanceRequest request) {
 		return invokeUpdateResponseBuilders(request)
-			.publishOn(Schedulers.parallel())
 			.doOnNext(response -> update(request, response)
 				.subscribe());
 	}
@@ -183,6 +182,7 @@ public class WorkflowServiceInstanceService implements ServiceInstanceService {
 	private Mono<Void> update(UpdateServiceInstanceRequest request, UpdateServiceInstanceResponse response) {
 		return stateRepository.saveState(request.getServiceInstanceId(),
 			OperationState.IN_PROGRESS, "update service instance started")
+			.publishOn(Schedulers.parallel())
 			.thenMany(invokeUpdateWorkflows(request, response)
 				.doOnRequest(l -> log.debug("Updating service instance {}", request))
 				.doOnComplete(() -> log.debug("Finished updating service instance {}", request))

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/service/WorkflowServiceInstanceServiceTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/service/WorkflowServiceInstanceServiceTest.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.appbroker.service;
 
 import java.sql.Timestamp;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 
@@ -52,7 +53,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -90,7 +90,7 @@ class WorkflowServiceInstanceServiceTest {
 	}
 
 	@Test
-	void createServiceInstance() {
+	void createServiceInstance() throws InterruptedException {
 		when(serviceInstanceStateRepository.saveState(anyString(), any(OperationState.class), anyString()))
 			.thenReturn(Mono.just(new ServiceInstanceState(OperationState.IN_PROGRESS, "create service instance started",
 				new Timestamp(Instant.now().minusSeconds(60).toEpochMilli()))))
@@ -123,11 +123,20 @@ class WorkflowServiceInstanceServiceTest {
 		given(createServiceInstanceWorkflow2.accept(request))
 			.willReturn(Mono.just(true));
 		given(createServiceInstanceWorkflow2.create(eq(request), eq(builtResponse)))
-			.willReturn(higherOrderFlow.mono());
+			.willReturn(Mono.just(true)
+				.flatMap(value -> {
+					try {
+						Thread.sleep(500);
+					} catch (InterruptedException e) {
+					}
+					return higherOrderFlow.mono();
+				}));
 		given(createServiceInstanceWorkflow2.buildResponse(eq(request), any(CreateServiceInstanceResponseBuilder.class)))
 			.willReturn(Mono.just(responseBuilder
 				.dashboardUrl("https://dashboard.example.com")
 				.operation("working2")));
+
+		InOrder createOrder = inOrder(createServiceInstanceWorkflow1, createServiceInstanceWorkflow2);
 
 		StepVerifier.create(workflowServiceInstanceService.createServiceInstance(request))
 			.assertNext(response -> {
@@ -138,31 +147,34 @@ class WorkflowServiceInstanceServiceTest {
 					.saveState(eq("foo"), eq(OperationState.SUCCEEDED), eq("create service instance completed"));
 				repoOrder.verifyNoMoreInteractions();
 
-				lowerOrderFlow.complete();
-				lowerOrderFlow.assertWasNotRequested();
-
-				higherOrderFlow.complete();
-				lowerOrderFlow.assertWasRequested();
-
-				InOrder createOrder = inOrder(createServiceInstanceWorkflow1, createServiceInstanceWorkflow2);
 				createOrder.verify(createServiceInstanceWorkflow2).buildResponse(eq(request),
 					any(CreateServiceInstanceResponseBuilder.class));
 				createOrder.verify(createServiceInstanceWorkflow1).buildResponse(eq(request),
 					any(CreateServiceInstanceResponseBuilder.class));
-				createOrder.verify(createServiceInstanceWorkflow2).create(request, responseBuilder.build());
-				createOrder.verify(createServiceInstanceWorkflow1).create(request, responseBuilder.build());
-				createOrder.verifyNoMoreInteractions();
 
 				assertThat(response).isNotNull();
 				assertThat(response.isAsync()).isTrue();
 				assertThat(response.getDashboardUrl()).isEqualTo("https://dashboard.example.com");
 				assertThat(response.getOperation()).isEqualTo("working2");
 			})
-			.verifyComplete();
+			.expectComplete()
+			.verifyThenAssertThat()
+			.tookLessThan(Duration.ofMillis(250));
+
+		lowerOrderFlow.complete();
+		lowerOrderFlow.assertWasNotRequested();
+
+		higherOrderFlow.complete();
+		Thread.sleep(600);
+		lowerOrderFlow.assertWasRequested();
+
+		createOrder.verify(createServiceInstanceWorkflow2).create(request, responseBuilder.build());
+		createOrder.verify(createServiceInstanceWorkflow1).create(request, responseBuilder.build());
+		createOrder.verifyNoMoreInteractions();
 	}
 
 	@Test
-	void createServiceInstanceWithAsyncError() {
+	void createServiceInstanceWithAsyncError() throws InterruptedException {
 		when(serviceInstanceStateRepository.saveState(anyString(), any(OperationState.class), anyString()))
 			.thenReturn(Mono.just(new ServiceInstanceState(OperationState.IN_PROGRESS, "create service instance started",
 				new Timestamp(Instant.now().minusSeconds(60).toEpochMilli()))))
@@ -189,27 +201,31 @@ class WorkflowServiceInstanceServiceTest {
 		given(createServiceInstanceWorkflow2.buildResponse(eq(request), any(CreateServiceInstanceResponseBuilder.class)))
 			.willReturn(Mono.just(responseBuilder));
 
+		InOrder repoOrder = inOrder(serviceInstanceStateRepository);
+		InOrder createOrder = inOrder(createServiceInstanceWorkflow1, createServiceInstanceWorkflow2);
+
 		StepVerifier.create(workflowServiceInstanceService.createServiceInstance(request))
 			.assertNext(response -> {
-				InOrder repoOrder = inOrder(serviceInstanceStateRepository);
 				repoOrder.verify(serviceInstanceStateRepository)
 					.saveState(eq("foo"), eq(OperationState.IN_PROGRESS), eq("create service instance started"));
-				repoOrder.verify(serviceInstanceStateRepository)
-					.saveState(eq("foo"), eq(OperationState.FAILED), eq("create foo error"));
-				repoOrder.verifyNoMoreInteractions();
 
-				InOrder createOrder = inOrder(createServiceInstanceWorkflow1, createServiceInstanceWorkflow2);
 				createOrder.verify(createServiceInstanceWorkflow2).buildResponse(eq(request),
 					any(CreateServiceInstanceResponseBuilder.class));
 				createOrder.verify(createServiceInstanceWorkflow1).buildResponse(eq(request),
 					any(CreateServiceInstanceResponseBuilder.class));
-				createOrder.verify(createServiceInstanceWorkflow2).create(request, responseBuilder.build());
-				createOrder.verify(createServiceInstanceWorkflow1).create(request, responseBuilder.build());
-				createOrder.verifyNoMoreInteractions();
 
 				assertThat(response).isNotNull();
 			})
 			.verifyComplete();
+
+		Thread.sleep(50);
+
+		repoOrder.verify(serviceInstanceStateRepository).saveState(eq("foo"), eq(OperationState.FAILED), eq("create foo error"));
+		repoOrder.verifyNoMoreInteractions();
+
+		createOrder.verify(createServiceInstanceWorkflow2).create(request, responseBuilder.build());
+		createOrder.verify(createServiceInstanceWorkflow1).create(request, responseBuilder.build());
+		createOrder.verifyNoMoreInteractions();
 	}
 
 	@Test
@@ -238,7 +254,7 @@ class WorkflowServiceInstanceServiceTest {
 	}
 
 	@Test
-	void createServiceInstanceWithNoAcceptsDoesNothing() {
+	void createServiceInstanceWithNoAcceptsDoesNothing() throws InterruptedException {
 		when(serviceInstanceStateRepository.saveState(anyString(), any(OperationState.class), anyString()))
 			.thenReturn(Mono.just(new ServiceInstanceState(OperationState.IN_PROGRESS, "create service instance started",
 				new Timestamp(Instant.now().minusSeconds(60).toEpochMilli()))))
@@ -255,6 +271,8 @@ class WorkflowServiceInstanceServiceTest {
 		given(createServiceInstanceWorkflow2.accept(request))
 			.willReturn(Mono.just(false));
 
+		InOrder createOrder = inOrder(createServiceInstanceWorkflow1, createServiceInstanceWorkflow2);
+
 		StepVerifier.create(workflowServiceInstanceService.createServiceInstance(request))
 			.assertNext(response -> {
 				InOrder repoOrder = inOrder(serviceInstanceStateRepository);
@@ -264,15 +282,22 @@ class WorkflowServiceInstanceServiceTest {
 					.saveState(eq("foo"), eq(OperationState.SUCCEEDED), eq("create service instance completed"));
 				repoOrder.verifyNoMoreInteractions();
 
-				verifyNoMoreInteractions(createServiceInstanceWorkflow1, createServiceInstanceWorkflow2);
+				createOrder.verify(createServiceInstanceWorkflow2).accept(eq(request));
+				createOrder.verify(createServiceInstanceWorkflow1).accept(eq(request));
 
 				assertThat(response).isNotNull();
 			})
 			.verifyComplete();
+
+		Thread.sleep(50);
+
+		createOrder.verify(createServiceInstanceWorkflow2).accept(eq(request));
+		createOrder.verify(createServiceInstanceWorkflow1).accept(eq(request));
+		createOrder.verifyNoMoreInteractions();
 	}
 
 	@Test
-	void deleteServiceInstance() {
+	void deleteServiceInstance() throws InterruptedException {
 		when(serviceInstanceStateRepository.saveState(anyString(), any(OperationState.class), anyString()))
 			.thenReturn(Mono.just(new ServiceInstanceState(OperationState.IN_PROGRESS, "delete service instance started",
 				new Timestamp(Instant.now().minusSeconds(60).toEpochMilli()))))
@@ -307,7 +332,16 @@ class WorkflowServiceInstanceServiceTest {
 			.willReturn(Mono.just(responseBuilder
 				.operation("working2")));
 		given(deleteServiceInstanceWorkflow2.delete(eq(request), eq(builtResponse)))
-			.willReturn(higherOrderFlow.mono());
+			.willReturn(Mono.just(true)
+				.flatMap(value -> {
+					try {
+						Thread.sleep(500);
+					} catch (InterruptedException e) {
+					}
+					return higherOrderFlow.mono();
+				}));
+
+		InOrder deleteOrder = inOrder(deleteServiceInstanceWorkflow1, deleteServiceInstanceWorkflow2);
 
 		StepVerifier.create(workflowServiceInstanceService.deleteServiceInstance(request))
 			.assertNext(response -> {
@@ -318,30 +352,33 @@ class WorkflowServiceInstanceServiceTest {
 					.saveState(eq("foo"), eq(OperationState.SUCCEEDED), eq("delete service instance completed"));
 				repoOrder.verifyNoMoreInteractions();
 
-				lowerOrderFlow.complete();
-				lowerOrderFlow.assertWasNotRequested();
-
-				higherOrderFlow.complete();
-				lowerOrderFlow.assertWasRequested();
-
-				InOrder deleteOrder = inOrder(deleteServiceInstanceWorkflow1, deleteServiceInstanceWorkflow2);
 				deleteOrder.verify(deleteServiceInstanceWorkflow2).buildResponse(eq(request),
 					any(DeleteServiceInstanceResponseBuilder.class));
 				deleteOrder.verify(deleteServiceInstanceWorkflow1).buildResponse(eq(request),
 					any(DeleteServiceInstanceResponseBuilder.class));
-				deleteOrder.verify(deleteServiceInstanceWorkflow2).delete(request, responseBuilder.build());
-				deleteOrder.verify(deleteServiceInstanceWorkflow1).delete(request, responseBuilder.build());
-				deleteOrder.verifyNoMoreInteractions();
 
 				assertThat(response).isNotNull();
 				assertThat(response.isAsync()).isTrue();
 				assertThat(response.getOperation()).isEqualTo("working2");
 			})
-			.verifyComplete();
+			.expectComplete()
+			.verifyThenAssertThat()
+			.tookLessThan(Duration.ofMillis(250));
+
+		lowerOrderFlow.complete();
+		lowerOrderFlow.assertWasNotRequested();
+
+		higherOrderFlow.complete();
+		Thread.sleep(600);
+		lowerOrderFlow.assertWasRequested();
+
+		deleteOrder.verify(deleteServiceInstanceWorkflow2).delete(request, responseBuilder.build());
+		deleteOrder.verify(deleteServiceInstanceWorkflow1).delete(request, responseBuilder.build());
+		deleteOrder.verifyNoMoreInteractions();
 	}
 
 	@Test
-	void deleteServiceInstanceWithAsyncError() {
+	void deleteServiceInstanceWithAsyncError() throws InterruptedException {
 		when(serviceInstanceStateRepository.saveState(anyString(), any(OperationState.class), anyString()))
 			.thenReturn(Mono.just(new ServiceInstanceState(OperationState.IN_PROGRESS, "delete service instance started",
 				new Timestamp(Instant.now().minusSeconds(60).toEpochMilli()))))
@@ -368,27 +405,31 @@ class WorkflowServiceInstanceServiceTest {
 		given(deleteServiceInstanceWorkflow2.buildResponse(eq(request), any(DeleteServiceInstanceResponseBuilder.class)))
 			.willReturn(Mono.just(responseBuilder));
 
+		InOrder repoOrder = inOrder(serviceInstanceStateRepository);
+		InOrder deleteOrder = inOrder(deleteServiceInstanceWorkflow1, deleteServiceInstanceWorkflow2);
+
 		StepVerifier.create(workflowServiceInstanceService.deleteServiceInstance(request))
 			.assertNext(response -> {
-				InOrder repoOrder = inOrder(serviceInstanceStateRepository);
 				repoOrder.verify(serviceInstanceStateRepository)
 					.saveState(eq("foo"), eq(OperationState.IN_PROGRESS), eq("delete service instance started"));
-				repoOrder.verify(serviceInstanceStateRepository)
-					.saveState(eq("foo"), eq(OperationState.FAILED), eq("delete foo error"));
-				repoOrder.verifyNoMoreInteractions();
 
-				InOrder deleteOrder = inOrder(deleteServiceInstanceWorkflow1, deleteServiceInstanceWorkflow2);
 				deleteOrder.verify(deleteServiceInstanceWorkflow2).buildResponse(eq(request),
 					any(DeleteServiceInstanceResponseBuilder.class));
 				deleteOrder.verify(deleteServiceInstanceWorkflow1).buildResponse(eq(request),
 					any(DeleteServiceInstanceResponseBuilder.class));
-				deleteOrder.verify(deleteServiceInstanceWorkflow2).delete(request, responseBuilder.build());
-				deleteOrder.verify(deleteServiceInstanceWorkflow1).delete(request, responseBuilder.build());
-				deleteOrder.verifyNoMoreInteractions();
 
 				assertThat(response).isNotNull();
 			})
 			.verifyComplete();
+
+		Thread.sleep(50);
+
+		repoOrder.verify(serviceInstanceStateRepository).saveState(eq("foo"), eq(OperationState.FAILED), eq("delete foo error"));
+		repoOrder.verifyNoMoreInteractions();
+
+		deleteOrder.verify(deleteServiceInstanceWorkflow2).delete(request, responseBuilder.build());
+		deleteOrder.verify(deleteServiceInstanceWorkflow1).delete(request, responseBuilder.build());
+		deleteOrder.verifyNoMoreInteractions();
 	}
 
 	@Test
@@ -417,7 +458,7 @@ class WorkflowServiceInstanceServiceTest {
 	}
 
 	@Test
-	void deleteServiceInstanceWithNoAcceptsDoesNothing() {
+	void deleteServiceInstanceWithNoAcceptsDoesNothing() throws InterruptedException {
 		when(serviceInstanceStateRepository.saveState(anyString(), any(OperationState.class), anyString()))
 			.thenReturn(Mono.just(new ServiceInstanceState(OperationState.IN_PROGRESS, "delete service instance started",
 				new Timestamp(Instant.now().minusSeconds(60).toEpochMilli()))))
@@ -434,6 +475,8 @@ class WorkflowServiceInstanceServiceTest {
 		given(deleteServiceInstanceWorkflow2.accept(request))
 			.willReturn(Mono.just(false));
 
+		InOrder deleteOrder = inOrder(deleteServiceInstanceWorkflow1, deleteServiceInstanceWorkflow2);
+
 		StepVerifier.create(workflowServiceInstanceService.deleteServiceInstance(request))
 			.assertNext(response -> {
 				InOrder repoOrder = inOrder(serviceInstanceStateRepository);
@@ -443,15 +486,22 @@ class WorkflowServiceInstanceServiceTest {
 					.saveState(eq("foo"), eq(OperationState.SUCCEEDED), eq("delete service instance completed"));
 				repoOrder.verifyNoMoreInteractions();
 
-				verifyNoMoreInteractions(createServiceInstanceWorkflow1, createServiceInstanceWorkflow2);
+				deleteOrder.verify(deleteServiceInstanceWorkflow2).accept(eq(request));
+				deleteOrder.verify(deleteServiceInstanceWorkflow1).accept(eq(request));
 
 				assertThat(response).isNotNull();
 			})
 			.verifyComplete();
+
+		Thread.sleep(50);
+
+		deleteOrder.verify(deleteServiceInstanceWorkflow2).accept(eq(request));
+		deleteOrder.verify(deleteServiceInstanceWorkflow1).accept(eq(request));
+		deleteOrder.verifyNoMoreInteractions();
 	}
 
 	@Test
-	void updateServiceInstance() {
+	void updateServiceInstance() throws InterruptedException {
 		when(serviceInstanceStateRepository.saveState(anyString(), any(OperationState.class), anyString()))
 			.thenReturn(Mono.just(new ServiceInstanceState(OperationState.IN_PROGRESS, "update service instance started",
 				new Timestamp(Instant.now().minusSeconds(60).toEpochMilli()))))
@@ -488,7 +538,16 @@ class WorkflowServiceInstanceServiceTest {
 				.dashboardUrl("https://dashboard.example.com")
 				.operation("working2")));
 		given(updateServiceInstanceWorkflow2.update(eq(request), eq(builtResponse)))
-			.willReturn(higherOrderFlow.mono());
+			.willReturn(Mono.just(true)
+				.flatMap(value -> {
+					try {
+						Thread.sleep(500);
+					} catch (InterruptedException e) {
+					}
+					return higherOrderFlow.mono();
+				}));
+
+		InOrder updateOrder = inOrder(updateServiceInstanceWorkflow1, updateServiceInstanceWorkflow2);
 
 		StepVerifier.create(workflowServiceInstanceService.updateServiceInstance(request))
 			.assertNext(response -> {
@@ -499,31 +558,34 @@ class WorkflowServiceInstanceServiceTest {
 					.saveState(eq("foo"), eq(OperationState.SUCCEEDED), eq("update service instance completed"));
 				repoOrder.verifyNoMoreInteractions();
 
-				lowerOrderFlow.complete();
-				lowerOrderFlow.assertWasNotRequested();
-
-				higherOrderFlow.complete();
-				lowerOrderFlow.assertWasRequested();
-
-				InOrder updateOrder = inOrder(updateServiceInstanceWorkflow1, updateServiceInstanceWorkflow2);
 				updateOrder.verify(updateServiceInstanceWorkflow2).buildResponse(eq(request),
 					any(UpdateServiceInstanceResponseBuilder.class));
 				updateOrder.verify(updateServiceInstanceWorkflow1).buildResponse(eq(request),
 					any(UpdateServiceInstanceResponseBuilder.class));
-				updateOrder.verify(updateServiceInstanceWorkflow2).update(request, builtResponse);
-				updateOrder.verify(updateServiceInstanceWorkflow1).update(request, builtResponse);
-				updateOrder.verifyNoMoreInteractions();
 
 				assertThat(response).isNotNull();
 				assertThat(response.isAsync()).isTrue();
 				assertThat(response.getDashboardUrl()).isEqualTo("https://dashboard.example.com");
 				assertThat(response.getOperation()).isEqualTo("working2");
 			})
-			.verifyComplete();
+			.expectComplete()
+			.verifyThenAssertThat()
+			.tookLessThan(Duration.ofMillis(250));
+
+		lowerOrderFlow.complete();
+		lowerOrderFlow.assertWasNotRequested();
+
+		higherOrderFlow.complete();
+		Thread.sleep(600);
+		lowerOrderFlow.assertWasRequested();
+
+		updateOrder.verify(updateServiceInstanceWorkflow2).update(request, builtResponse);
+		updateOrder.verify(updateServiceInstanceWorkflow1).update(request, builtResponse);
+		updateOrder.verifyNoMoreInteractions();
 	}
 
 	@Test
-	void updateServiceInstanceWithAsyncError() {
+	void updateServiceInstanceWithAsyncError() throws InterruptedException {
 		when(serviceInstanceStateRepository.saveState(anyString(), any(OperationState.class), anyString()))
 			.thenReturn(Mono.just(new ServiceInstanceState(OperationState.IN_PROGRESS, "update service instance started",
 				new Timestamp(Instant.now().minusSeconds(60).toEpochMilli()))))
@@ -550,27 +612,31 @@ class WorkflowServiceInstanceServiceTest {
 		given(updateServiceInstanceWorkflow2.buildResponse(eq(request), any(UpdateServiceInstanceResponseBuilder.class)))
 			.willReturn(Mono.just(responseBuilder));
 
+		InOrder repoOrder = inOrder(serviceInstanceStateRepository);
+		InOrder updateOrder = inOrder(updateServiceInstanceWorkflow1, updateServiceInstanceWorkflow2);
+
 		StepVerifier.create(workflowServiceInstanceService.updateServiceInstance(request))
 			.assertNext(response -> {
-				InOrder repoOrder = inOrder(serviceInstanceStateRepository);
 				repoOrder.verify(serviceInstanceStateRepository)
 					.saveState(eq("foo"), eq(OperationState.IN_PROGRESS), eq("update service instance started"));
-				repoOrder.verify(serviceInstanceStateRepository)
-					.saveState(eq("foo"), eq(OperationState.FAILED), eq("update foo error"));
-				repoOrder.verifyNoMoreInteractions();
 
-				InOrder updateOrder = inOrder(updateServiceInstanceWorkflow1, updateServiceInstanceWorkflow2);
 				updateOrder.verify(updateServiceInstanceWorkflow2).buildResponse(eq(request),
 					any(UpdateServiceInstanceResponseBuilder.class));
 				updateOrder.verify(updateServiceInstanceWorkflow1).buildResponse(eq(request),
 					any(UpdateServiceInstanceResponseBuilder.class));
-				updateOrder.verify(updateServiceInstanceWorkflow2).update(request, responseBuilder.build());
-				updateOrder.verify(updateServiceInstanceWorkflow1).update(request, responseBuilder.build());
-				updateOrder.verifyNoMoreInteractions();
 
 				assertThat(response).isNotNull();
 			})
 			.verifyComplete();
+
+		Thread.sleep(50);
+
+		repoOrder.verify(serviceInstanceStateRepository).saveState(eq("foo"), eq(OperationState.FAILED), eq("update foo error"));
+		repoOrder.verifyNoMoreInteractions();
+
+		updateOrder.verify(updateServiceInstanceWorkflow2).update(request, responseBuilder.build());
+		updateOrder.verify(updateServiceInstanceWorkflow1).update(request, responseBuilder.build());
+		updateOrder.verifyNoMoreInteractions();
 	}
 
 	@Test
@@ -599,7 +665,7 @@ class WorkflowServiceInstanceServiceTest {
 	}
 
 	@Test
-	void updateServiceInstanceWithNoAcceptsDoesNothing() {
+	void updateServiceInstanceWithNoAcceptsDoesNothing() throws InterruptedException {
 		when(serviceInstanceStateRepository.saveState(anyString(), any(OperationState.class), anyString()))
 			.thenReturn(Mono.just(new ServiceInstanceState(OperationState.IN_PROGRESS, "update service instance started",
 				new Timestamp(Instant.now().minusSeconds(60).toEpochMilli()))))
@@ -616,6 +682,8 @@ class WorkflowServiceInstanceServiceTest {
 		given(updateServiceInstanceWorkflow2.accept(request))
 			.willReturn(Mono.just(false));
 
+		InOrder updateOrder = inOrder(updateServiceInstanceWorkflow1, updateServiceInstanceWorkflow2);
+
 		StepVerifier.create(workflowServiceInstanceService.updateServiceInstance(request))
 			.assertNext(response -> {
 				InOrder repoOrder = inOrder(serviceInstanceStateRepository);
@@ -625,11 +693,18 @@ class WorkflowServiceInstanceServiceTest {
 					.saveState(eq("foo"), eq(OperationState.SUCCEEDED), eq("update service instance completed"));
 				repoOrder.verifyNoMoreInteractions();
 
-				verifyNoMoreInteractions(updateServiceInstanceWorkflow1, updateServiceInstanceWorkflow2);
+				updateOrder.verify(updateServiceInstanceWorkflow2).accept(eq(request));
+				updateOrder.verify(updateServiceInstanceWorkflow1).accept(eq(request));
 
 				assertThat(response).isNotNull();
 			})
 			.verifyComplete();
+
+		Thread.sleep(50);
+
+		updateOrder.verify(updateServiceInstanceWorkflow2).accept(eq(request));
+		updateOrder.verify(updateServiceInstanceWorkflow1).accept(eq(request));
+		updateOrder.verifyNoMoreInteractions();
 	}
 
 	@Order(Ordered.HIGHEST_PRECEDENCE)


### PR DESCRIPTION
…and return a response as soon as possible

Resolves #256

The `sleep` calls within the mono should simulate a long running computation within the workflow layer. If you revert the changes in the implementation, the tests fail.
I know the solution is looking odd with all the `sleep` calls. I'm aware that such kind of tests tend to become flaky. Unfortunately I don't have a better idea how to handle this, as the execution of the workflows is now really async.
In case you've a better idea, how to test this, feel free to change. :)