### PR TITLE
Make error reporting more verbose

### DIFF
--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/DefaultBackingAppDeploymentService.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/DefaultBackingAppDeploymentService.java
@@ -42,8 +42,8 @@ public class DefaultBackingAppDeploymentService implements BackingAppDeploymentS
 			.doOnRequest(l -> log.debug("Deploying applications {}", backingApps))
 			.doOnEach(response -> log.debug("Finished deploying application {}", response))
 			.doOnComplete(() -> log.debug("Finished deploying application {}", backingApps))
-			.doOnError(exception -> log.error("Error deploying applications {} with error '{}'",
-				backingApps, exception.getMessage()));
+			.doOnError(exception -> log.error(String.format("Error deploying applications %s with error '%s'",
+				backingApps, exception.getMessage()), exception));
 	}
 
 	@Override
@@ -56,7 +56,7 @@ public class DefaultBackingAppDeploymentService implements BackingAppDeploymentS
 			.doOnRequest(l -> log.debug("Updating applications {}", backingApps))
 			.doOnEach(response -> log.debug("Finished updating application {}", response))
 			.doOnComplete(() -> log.debug("Finished updating application {}", backingApps))
-			.doOnError(exception -> log.error("Error updating applications {} with error {}", backingApps, exception));
+			.doOnError(exception -> log.error(String.format("Error updating applications %s with error '%s'", backingApps, exception)));
 	}
 
 	@Override
@@ -69,7 +69,7 @@ public class DefaultBackingAppDeploymentService implements BackingAppDeploymentS
 			.doOnRequest(l -> log.debug("Undeploying applications {}", backingApps))
 			.doOnEach(response -> log.debug("Finished undeploying application {}", response))
 			.doOnComplete(() -> log.debug("Finished undeploying application {}", backingApps))
-			.doOnError(exception -> log.error("Error undeploying applications {} with error '{}'",
-				backingApps, exception.getMessage()));
+			.doOnError(exception -> log.error(String.format("Error undeploying applications %s with error '%s'",
+				backingApps, exception.getMessage()), exception));
 	}
 }

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/DefaultBackingServicesProvisionService.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/DefaultBackingServicesProvisionService.java
@@ -43,8 +43,8 @@ public class DefaultBackingServicesProvisionService implements BackingServicesPr
 			.doOnRequest(l -> log.debug("Creating backing services {}", backingServices))
 			.doOnEach(response -> log.debug("Finished creating backing service {}", response))
 			.doOnComplete(() -> log.debug("Finished creating backing services {}", backingServices))
-			.doOnError(exception -> log.error("Error creating backing services {} with error '{}'",
-				backingServices, exception.getMessage()));
+			.doOnError(exception -> log.error(String.format("Error creating backing services %s with error '%s'",
+				backingServices, exception.getMessage()), exception));
 	}
 
 	@Override
@@ -57,8 +57,8 @@ public class DefaultBackingServicesProvisionService implements BackingServicesPr
 			.doOnRequest(l -> log.debug("Updating backing services {}", backingServices))
 			.doOnEach(response -> log.debug("Finished updating backing service {}", response))
 			.doOnComplete(() -> log.debug("Finished updating backing services {}", backingServices))
-			.doOnError(exception -> log.error("Error updating backing services {} with error '{}'",
-				backingServices, exception.getMessage()));
+			.doOnError(exception -> log.error(String.format("Error updating backing services %s with error '%s'",
+				backingServices, exception.getMessage()), exception));
 	}
 
 	@Override
@@ -71,7 +71,7 @@ public class DefaultBackingServicesProvisionService implements BackingServicesPr
 			.doOnRequest(l -> log.debug("Deleting backing services {}", backingServices))
 			.doOnEach(response -> log.debug("Finished deleting backing service {}", response))
 			.doOnComplete(() -> log.debug("Finished deleting backing services {}", backingServices))
-			.doOnError(exception -> log.error("Error deleting backing services {} with error '{}'",
-				backingServices, exception.getMessage()));
+			.doOnError(exception -> log.error(String.format("Error deleting backing services %s with error '%s'",
+				backingServices, exception.getMessage()), exception));
 	}
 }

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/DeployerClient.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/DeployerClient.java
@@ -47,8 +47,8 @@ public class DeployerClient {
 				.build())
 			.doOnRequest(l -> log.debug("Deploying application {}", backingApplication))
 			.doOnSuccess(response -> log.debug("Finished deploying application {}", backingApplication))
-			.doOnError(exception -> log.error("Error deploying application {} with error '{}'",
-				backingApplication, exception.getMessage()))
+			.doOnError(exception -> log.error(String.format("Error deploying application %s with error '%s'",
+				backingApplication, exception.getMessage()), exception))
 			.map(DeployApplicationResponse::getName);
 	}
 
@@ -67,8 +67,8 @@ public class DeployerClient {
 				.build())
 			.doOnRequest(l -> log.debug("Updating application {}", backingApplication))
 			.doOnSuccess(response -> log.debug("Finished updating application {}", backingApplication))
-			.doOnError(exception -> log.error("Error updating application {} with error {}",
-				backingApplication, exception))
+			.doOnError(exception -> log.error(String.format("Error updating application %s with error '%s'",
+				backingApplication, exception), exception))
 			.map(UpdateApplicationResponse::getName);
 	}
 
@@ -81,8 +81,8 @@ public class DeployerClient {
 				.build())
 			.doOnRequest(l -> log.debug("Undeploying application {}", backingApplication))
 			.doOnSuccess(response -> log.debug("Finished undeploying application {}", backingApplication))
-			.doOnError(exception -> log.error("Error undeploying application {} with error '{}'",
-				backingApplication, exception.getMessage()))
+			.doOnError(exception -> log.error(String.format("Error undeploying application %s with error '%s'",
+				backingApplication, exception.getMessage()), exception))
 			.onErrorReturn(UndeployApplicationResponse.builder()
 				.name(backingApplication.getName())
 				.build())
@@ -102,8 +102,8 @@ public class DeployerClient {
 					.build())
 			.doOnRequest(l -> log.debug("Creating backing service {}", backingService.getName()))
 			.doOnSuccess(response -> log.debug("Finished creating backing service {}", backingService.getName()))
-			.doOnError(exception -> log.error("Error creating backing service {} with error '{}'",
-				backingService.getName(), exception.getMessage()))
+			.doOnError(exception -> log.error(String.format("Error creating backing service %s with error '%s'",
+				backingService.getName(), exception.getMessage()), exception))
 			.map(CreateServiceInstanceResponse::getName);
 	}
 
@@ -119,8 +119,8 @@ public class DeployerClient {
 					.build())
 			.doOnRequest(l -> log.debug("Updating backing service {}", backingService.getName()))
 			.doOnSuccess(response -> log.debug("Finished updating backing service {}", backingService.getName()))
-			.doOnError(exception -> log.error("Error updating backing service {} with error '{}'",
-				backingService.getName(), exception.getMessage()))
+			.doOnError(exception -> log.error(String.format("Error updating backing service %s with error '%s'",
+				backingService.getName(), exception.getMessage()), exception))
 			.map(UpdateServiceInstanceResponse::getName);
 	}
 
@@ -134,8 +134,8 @@ public class DeployerClient {
 					.build())
 			.doOnRequest(l -> log.debug("Deleting backing service {}", backingService.getName()))
 			.doOnSuccess(response -> log.debug("Finished deleting backing service {}", backingService.getName()))
-			.doOnError(exception -> log.error("Error deleting backing service {} with error '{}'",
-				backingService.getName(), exception.getMessage()))
+			.doOnError(exception -> log.error(String.format("Error deleting backing service %s with error '%s'",
+				backingService.getName(), exception.getMessage()), exception))
 			.onErrorReturn(DeleteServiceInstanceResponse.builder()
 				.name(backingService.getServiceInstanceName())
 				.build())

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/manager/BackingAppManagementService.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/manager/BackingAppManagementService.java
@@ -61,8 +61,8 @@ public class BackingAppManagementService {
 				.doOnRequest(l -> log.debug("Stopping applications {}", backingApps))
 				.doOnEach(response -> log.debug("Finished stopping application {}", response))
 				.doOnComplete(() -> log.debug("Finished stopping application {}", backingApps))
-				.doOnError(exception -> log.error("Error stopping applications {} with error '{}'",
-					backingApps, exception.getMessage())))
+				.doOnError(exception -> log.error(String.format("Error stopping applications %s with error '%s'",
+					backingApps, exception.getMessage()), exception)))
 			.then();
 	}
 
@@ -75,8 +75,8 @@ public class BackingAppManagementService {
 				.doOnRequest(l -> log.debug("Starting applications {}", backingApps))
 				.doOnEach(response -> log.debug("Finished starting application {}", response))
 				.doOnComplete(() -> log.debug("Finished starting application {}", backingApps))
-				.doOnError(exception -> log.error("Error starting applications {} with error '{}'",
-					backingApps, exception.getMessage())))
+				.doOnError(exception -> log.error(String.format("Error starting applications %s with error '%s'",
+					backingApps, exception.getMessage()), exception)))
 			.then();
 	}
 
@@ -89,8 +89,8 @@ public class BackingAppManagementService {
 				.doOnRequest(l -> log.debug("Restarting applications {}", backingApps))
 				.doOnEach(response -> log.debug("Finished restarting application {}", response))
 				.doOnComplete(() -> log.debug("Finished restarting application {}", backingApps))
-				.doOnError(exception -> log.error("Error restarting applications {} with error '{}'",
-					backingApps, exception.getMessage())))
+				.doOnError(exception -> log.error(String.format("Error restarting applications %s with error '%s'",
+					backingApps, exception.getMessage()), exception)))
 			.then();
 	}
 
@@ -103,8 +103,8 @@ public class BackingAppManagementService {
 				.doOnRequest(l -> log.debug("Restaging applications {}", backingApps))
 				.doOnEach(response -> log.debug("Finished restaging application {}", response))
 				.doOnComplete(() -> log.debug("Finished restaging application {}", backingApps))
-				.doOnError(exception -> log.error("Error restaging applications {} with error '{}'",
-					backingApps, exception.getMessage())))
+				.doOnError(exception -> log.error(String.format("Error restaging applications %s with error '%s'",
+					backingApps, exception.getMessage()), exception)))
 			.then();
 	}
 

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/manager/ManagementClient.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/manager/ManagementClient.java
@@ -40,8 +40,8 @@ public class ManagementClient {
 				.build())
 				.doOnRequest(l -> log.debug("Starting application {}", backingApp))
 				.doOnSuccess(response -> log.debug("Finished starting application {}", backingApp))
-				.doOnError(exception -> log.error("Error starting application {} with error '{}'",
-					backingApp, exception.getMessage())));
+				.doOnError(exception -> log.error(String.format("Error starting application %s with error '%s'",
+					backingApp, exception.getMessage()), exception)));
 	}
 
 	Mono<Void> stop(BackingApplication backingApplication) {
@@ -52,8 +52,8 @@ public class ManagementClient {
 				.build())
 				.doOnRequest(l -> log.debug("Stopping application {}", backingApp))
 				.doOnSuccess(response -> log.debug("Finished stopping application {}", backingApp))
-				.doOnError(exception -> log.error("Error stopping application {} with error '{}'",
-					backingApp, exception.getMessage())));
+				.doOnError(exception -> log.error(String.format("Error stopping application %s with error '%s'",
+					backingApp, exception.getMessage()), exception)));
 	}
 
 	Mono<Void> restart(BackingApplication backingApplication) {
@@ -64,8 +64,8 @@ public class ManagementClient {
 				.build())
 				.doOnRequest(l -> log.debug("Restarting application {}", backingApp))
 				.doOnSuccess(response -> log.debug("Finished restarting application {}", backingApp))
-				.doOnError(exception -> log.error("Error restarting application {} with error '{}'",
-					backingApp, exception.getMessage())));
+				.doOnError(exception -> log.error(String.format("Error restarting application %s with error '%s'",
+					backingApp, exception.getMessage()), exception)));
 	}
 
 	Mono<Void> restage(BackingApplication backingApplication) {
@@ -76,7 +76,7 @@ public class ManagementClient {
 				.build())
 				.doOnRequest(l -> log.debug("Restaging application {}", backingApp))
 				.doOnSuccess(response -> log.debug("Finished restaging application {}", backingApp))
-				.doOnError(exception -> log.error("Error restaging application {} with error '{}'",
-					backingApp, exception.getMessage())));
+				.doOnError(exception -> log.error(String.format("Error restaging application %s with error '%s'",
+					backingApp, exception.getMessage()), exception)));
 	}
 }

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/service/WorkflowServiceInstanceBindingService.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/service/WorkflowServiceInstanceBindingService.java
@@ -136,8 +136,8 @@ public class WorkflowServiceInstanceBindingService implements ServiceInstanceBin
 			.thenMany(invokeCreateWorkflows(request, response)
 				.doOnRequest(l -> log.debug("Creating service instance binding {}", request))
 				.doOnComplete(() -> log.debug("Finished creating service instance binding {}", request))
-				.doOnError(exception -> log.error("Error creating service instance binding {} with error '{}'",
-					request, exception.getMessage())))
+				.doOnError(exception -> log.error(String.format("Error creating service instance binding %s with error '%s'",
+					request, exception.getMessage()), exception)))
 			.thenEmpty(stateRepository.saveState(request.getServiceInstanceId(), request.getBindingId(),
 				OperationState.SUCCEEDED, "create service instance binding completed")
 				.then())
@@ -192,8 +192,8 @@ public class WorkflowServiceInstanceBindingService implements ServiceInstanceBin
 			.thenMany(invokeDeleteWorkflows(request, response)
 				.doOnRequest(l -> log.debug("Deleting service instance binding {}", request))
 				.doOnComplete(() -> log.debug("Finished deleting service instance binding {}", request))
-				.doOnError(exception -> log.error("Error deleting service instance binding {} with error '{}'",
-					request, exception.getMessage())))
+				.doOnError(exception -> log.error(String.format("Error deleting service instance binding %s with error '%s'",
+					request, exception.getMessage()), exception)))
 			.thenEmpty(stateRepository.saveState(request.getServiceInstanceId(), request.getBindingId(),
 				OperationState.SUCCEEDED, "delete service instance binding completed")
 				.then())

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/service/WorkflowServiceInstanceService.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/service/WorkflowServiceInstanceService.java
@@ -100,8 +100,8 @@ public class WorkflowServiceInstanceService implements ServiceInstanceService {
 			.thenMany(invokeCreateWorkflows(request, response)
 				.doOnRequest(l -> log.debug("Creating service instance {}", request))
 				.doOnComplete(() -> log.debug("Finished creating service instance {}", request))
-				.doOnError(exception -> log.error("Error creating service instance {} with error '{}'",
-					request, exception.getMessage())))
+				.doOnError(exception -> log.error(String.format("Error creating service instance %s with error '%s'",
+					request, exception.getMessage()), exception)))
 			.thenEmpty(stateRepository.saveState(request.getServiceInstanceId(),
 				OperationState.SUCCEEDED, "create service instance completed")
 				.then())
@@ -143,8 +143,8 @@ public class WorkflowServiceInstanceService implements ServiceInstanceService {
 			.thenMany(invokeDeleteWorkflows(request, response)
 				.doOnRequest(l -> log.debug("Deleting service instance {}", request))
 				.doOnComplete(() -> log.debug("Finished deleting service instance {}", request))
-				.doOnError(exception -> log.error("Error deleting service instance {} with error '{}'",
-					request, exception.getMessage())))
+				.doOnError(exception -> log.error(String.format("Error deleting service instance {} with error '{}'",
+					request, exception.getMessage()), exception)))
 			.thenEmpty(stateRepository.saveState(request.getServiceInstanceId(),
 				OperationState.SUCCEEDED, "delete service instance completed")
 				.then())
@@ -186,8 +186,8 @@ public class WorkflowServiceInstanceService implements ServiceInstanceService {
 			.thenMany(invokeUpdateWorkflows(request, response)
 				.doOnRequest(l -> log.debug("Updating service instance {}", request))
 				.doOnComplete(() -> log.debug("Finished updating service instance {}", request))
-				.doOnError(exception -> log.error("Error updating service instance {} with error '{}'",
-					request, exception.getMessage())))
+				.doOnError(exception -> log.error(String.format("Error updating service instance %s with error '%s'",
+					request, exception.getMessage()), exception)))
 			.thenEmpty(stateRepository.saveState(request.getServiceInstanceId(),
 				OperationState.SUCCEEDED, "update service instance completed")
 				.then())

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentCreateServiceInstanceWorkflow.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentCreateServiceInstanceWorkflow.java
@@ -85,8 +85,8 @@ public class AppDeploymentCreateServiceInstanceWorkflow
 				request.getServiceDefinition().getName(), request.getPlan().getName()))
 			.doOnComplete(() -> log.debug("Finished creating backing services for {}/{}",
 				request.getServiceDefinition().getName(), request.getPlan().getName()))
-			.doOnError(exception -> log.error("Error creating backing services for {}/{} with error '{}'",
-				request.getServiceDefinition().getName(), request.getPlan().getName(), exception.getMessage()));
+			.doOnError(exception -> log.error(String.format("Error creating backing services for %s/%s with error '%s'",
+				request.getServiceDefinition().getName(), request.getPlan().getName(), exception.getMessage()), exception));
 	}
 
 	private Flux<String> deployBackingApplications(CreateServiceInstanceRequest request) {
@@ -106,8 +106,8 @@ public class AppDeploymentCreateServiceInstanceWorkflow
 				request.getServiceDefinition().getName(), request.getPlan().getName()))
 			.doOnComplete(() -> log.debug("Finished deploying backing applications for {}/{}",
 				request.getServiceDefinition().getName(), request.getPlan().getName()))
-			.doOnError(exception -> log.error("Error deploying backing applications for {}/{} with error '{}'",
-				request.getServiceDefinition().getName(), request.getPlan().getName(), exception.getMessage()));
+			.doOnError(exception -> log.error(String.format("Error deploying backing applications for %s/%s with error '%s'",
+				request.getServiceDefinition().getName(), request.getPlan().getName(), exception.getMessage()), exception));
 	}
 
 	@Override

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentDeleteServiceInstanceWorkflow.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentDeleteServiceInstanceWorkflow.java
@@ -74,8 +74,8 @@ public class AppDeploymentDeleteServiceInstanceWorkflow
 				request.getServiceDefinition().getName(), request.getPlan().getName()))
 			.doOnComplete(() -> log.debug("Finished deleting backing services for {}/{}",
 				request.getServiceDefinition().getName(), request.getPlan().getName()))
-			.doOnError(exception -> log.error("Error deleting backing services for {}/{} with error '{}'",
-				request.getServiceDefinition().getName(), request.getPlan().getName(), exception.getMessage()));
+			.doOnError(exception -> log.error(String.format("Error deleting backing services for %s/%s with error '%s'",
+				request.getServiceDefinition().getName(), request.getPlan().getName(), exception.getMessage()), exception));
 	}
 
 	private Flux<String> undeployBackingApplications(DeleteServiceInstanceRequest request) {
@@ -92,8 +92,8 @@ public class AppDeploymentDeleteServiceInstanceWorkflow
 				request.getServiceDefinition().getName(), request.getPlan().getName()))
 			.doOnComplete(() -> log.debug("Finished undeploying backing applications for {}/{}",
 				request.getServiceDefinition().getName(), request.getPlan().getName()))
-			.doOnError(exception -> log.error("Error undeploying backing applications for {}/{} with error '{}'",
-				request.getServiceDefinition().getName(), request.getPlan().getName(), exception.getMessage()));
+			.doOnError(exception -> log.error(String.format("Error undeploying backing applications for %s/%s with error '%s'",
+				request.getServiceDefinition().getName(), request.getPlan().getName(), exception.getMessage()), exception));
 	}
 
 	@Override

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentUpdateServiceInstanceWorkflow.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentUpdateServiceInstanceWorkflow.java
@@ -80,8 +80,8 @@ public class AppDeploymentUpdateServiceInstanceWorkflow
 				request.getServiceDefinition().getName(), request.getPlan().getName()))
 			.doOnComplete(() -> log.debug("Finished updating backing services for {}/{}",
 				request.getServiceDefinition().getName(), request.getPlan().getName()))
-			.doOnError(exception -> log.error("Error updating backing services for {}/{} with error '{}'",
-				request.getServiceDefinition().getName(), request.getPlan().getName(), exception.getMessage()));
+			.doOnError(exception -> log.error(String.format("Error updating backing services for %s/%s with error '%s'",
+				request.getServiceDefinition().getName(), request.getPlan().getName(), exception.getMessage()), exception));
 	}
 
 	private Flux<String> updateBackingApplications(UpdateServiceInstanceRequest request) {
@@ -97,8 +97,8 @@ public class AppDeploymentUpdateServiceInstanceWorkflow
 				request.getServiceDefinition().getName(), request.getPlan().getName()))
 			.doOnComplete(() -> log.debug("Finished updating backing applications for {}/{}",
 				request.getServiceDefinition().getName(), request.getPlan().getName()))
-			.doOnError(exception -> log.error("Error updating backing applications for {}/{} with error '{}'",
-				request.getServiceDefinition().getName(), request.getPlan().getName(), exception.getMessage()));
+			.doOnError(exception -> log.error(String.format("Error updating backing applications for %s/%s with error '%s'",
+				request.getServiceDefinition().getName(), request.getPlan().getName(), exception.getMessage()), exception));
 	}
 
 	@Override

--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployer.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployer.java
@@ -982,8 +982,8 @@ public class CloudFoundryAppDeployer implements AppDeployer, ResourceLoaderAware
 				.builder()
 				.name(serviceInstanceName)
 				.build())
-				.doOnError(exception -> logger.debug("Error deleting service instance {} with error '{}'",
-					 serviceInstanceName, exception.getMessage()))
+				.doOnError(exception -> logger.debug(String.format("Error deleting service instance %s with error '%s'",
+					 serviceInstanceName, exception.getMessage()), exception))
 				.onErrorResume(e -> Mono.empty());
 	}
 

--- a/spring-cloud-app-broker-security-credhub/src/main/java/org/springframework/cloud/appbroker/workflow/binding/CredHubPersistingCreateServiceInstanceAppBindingWorkflow.java
+++ b/spring-cloud-app-broker-security-credhub/src/main/java/org/springframework/cloud/appbroker/workflow/binding/CredHubPersistingCreateServiceInstanceAppBindingWorkflow.java
@@ -61,8 +61,8 @@ public class CredHubPersistingCreateServiceInstanceAppBindingWorkflow
 						.flatMap(credentialName -> persistBindingCredentials(request, response, credentialName)
 							.doOnRequest(l -> LOG.debug("Storing binding credentials with name '{}' in CredHub", credentialName.getName()))
 							.doOnSuccess(r -> LOG.debug("Finished storing binding credentials with name '{}' in CredHub", credentialName.getName()))
-							.doOnError(exception -> LOG.error("Error storing binding credentials with name '{}' in CredHub with error: {}",
-								credentialName.getName(), exception.getMessage())));
+							.doOnError(exception -> LOG.error(String.format("Error storing binding credentials with name '%s' in CredHub with error: '%s'",
+								credentialName.getName(), exception.getMessage()), exception)));
 				}
 				return Mono.just(responseBuilder);
 			});

--- a/spring-cloud-app-broker-security-credhub/src/main/java/org/springframework/cloud/appbroker/workflow/binding/CredHubPersistingDeleteServiceInstanceBindingWorkflow.java
+++ b/spring-cloud-app-broker-security-credhub/src/main/java/org/springframework/cloud/appbroker/workflow/binding/CredHubPersistingDeleteServiceInstanceBindingWorkflow.java
@@ -48,8 +48,8 @@ public class CredHubPersistingDeleteServiceInstanceBindingWorkflow
 			.flatMap(credentialName -> deleteBindingCredentials(credentialName)
 					.doOnRequest(l -> LOG.debug("Deleting binding credentials with name '{}' in CredHub", credentialName.getName()))
 					.doOnSuccess(r -> LOG.debug("Finished deleting binding credentials with name '{}' in CredHub", credentialName.getName()))
-					.doOnError(exception -> LOG.error("Error deleting binding credentials with name '{}' in CredHub with error: {}",
-						credentialName.getName(), exception.getMessage())))
+					.doOnError(exception -> LOG.error(String.format("Error deleting binding credentials with name '%s' in CredHub with error: '%s'",
+						credentialName.getName(), exception.getMessage()), exception)))
 			.thenReturn(responseBuilder);
 	}
 


### PR DESCRIPTION
Before only error message was dispalyed in logs providing no information, like exception details or stacktrace. Now error message is logged together with exception, including stacktrace.