### PR TITLE
Add domains property

### DIFF
--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployer.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployer.java
@@ -526,6 +526,10 @@ public class CloudFoundryAppDeployer implements AppDeployer, ResourceLoaderAware
 			manifest.routes(routes);
 		}
 
+		if (!domains(deploymentProperties).isEmpty()) {
+			manifest.domains(domains(deploymentProperties));
+		}
+
 		if (getDockerImage(appResource) == null) {
 			manifest.buildpack(buildpack(deploymentProperties));
 		} else {
@@ -721,6 +725,13 @@ public class CloudFoundryAppDeployer implements AppDeployer, ResourceLoaderAware
 	private String domain(Map<String, String> properties) {
 		return Optional.ofNullable(properties.get(CloudFoundryDeploymentProperties.DOMAIN_PROPERTY))
 			.orElse(this.defaultDeploymentProperties.getDomain());
+	}
+
+	private Set<String> domains(Map<String, String> properties) {
+		Set<String> domains = new HashSet<>();
+		domains.addAll(this.defaultDeploymentProperties.getDomains());
+		domains.addAll(StringUtils.commaDelimitedListToSet(properties.get(CloudFoundryDeploymentProperties.DOMAINS_PROPERTY)));
+		return domains;
 	}
 
 	private ApplicationHealthCheck healthCheck(Map<String, String> properties) {

--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryDeploymentProperties.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryDeploymentProperties.java
@@ -49,6 +49,8 @@ public class CloudFoundryDeploymentProperties extends DeploymentProperties {
 
 	static final String DOMAIN_PROPERTY = "domain";
 
+	static final String DOMAINS_PROPERTY = "domains";
+
 	static final String BUILDPACK_PROPERTY_KEY = "buildpack";
 
 	static final String JAVA_OPTS_PROPERTY_KEY = "javaOpts";
@@ -57,6 +59,11 @@ public class CloudFoundryDeploymentProperties extends DeploymentProperties {
 	 * The domain to use when mapping routes for applications.
 	 */
 	private String domain;
+
+	/**
+	 * The list of domain to use when mapping routes for applications.
+	 */
+	private Set<String> domains = new HashSet<>();
 
 	/**
 	 * The routes that the application should be bound to.
@@ -170,6 +177,14 @@ public class CloudFoundryDeploymentProperties extends DeploymentProperties {
 
 	public void setDomain(String domain) {
 		this.domain = domain;
+	}
+
+	public Set<String> getDomains() {
+		return domains;
+	}
+
+	public void setDomains(Set<String> domains) {
+		this.domains = domains;
 	}
 
 	public Set<String> getRoutes() {


### PR DESCRIPTION
Having multiple domains is supported by CAPI and `domain` is just a configuration
shortcut. However for compatibility reasons existing `domain` property
can't be removed, instead new `domains` property is added. When both are
provided in the request or default properties, `domains` will take priority.