### PR TITLE
Support brokered service without backing application

### DIFF
--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentInstanceWorkflow.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentInstanceWorkflow.java
@@ -42,7 +42,12 @@ public class AppDeploymentInstanceWorkflow {
 	protected Mono<Boolean> accept(ServiceDefinition serviceDefinition, Plan plan) {
 		return getBackingApplicationsForService(serviceDefinition, plan)
 			.map(backingApplications -> !backingApplications.isEmpty())
-			.defaultIfEmpty(false);
+			.filter(Boolean::booleanValue) // filter out Boolean.False to proceed with flux, see https://stackoverflow.com/questions/49860558/project-reactor-conditional-execution
+			.switchIfEmpty(
+				getBackingServicesForService(serviceDefinition, plan)
+				.map(backingServices -> !backingServices.isEmpty())
+				.defaultIfEmpty(false)
+			);
 	}
 
 	protected TargetSpec getTargetForService(ServiceDefinition serviceDefinition, Plan plan) {

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentInstanceWorkflowTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentInstanceWorkflowTest.java
@@ -94,10 +94,11 @@ class AppDeploymentInstanceWorkflowTest {
 
 	@Test
 	void doNotAcceptWithMatchingServiceWithoutBackingServiceNorBackingApplication() {
-		ServiceDefinition serviceDefinition = buildServiceDefinition("service3_without_backing_app_nor_service", "plan1");
+		ServiceDefinition serviceDefinition = buildServiceDefinition("service3_without_backing_app_nor_service",
+			"plan1");
 		StepVerifier
 			.create(workflow.accept(serviceDefinition, serviceDefinition.getPlans().get(0)))
-			.expectNextMatches(value -> ! value)
+			.expectNextMatches(value -> !value)
 			.verifyComplete();
 	}
 

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentInstanceWorkflowTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentInstanceWorkflowTest.java
@@ -20,7 +20,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 
-import org.springframework.cloud.appbroker.deployer.*;
+import org.springframework.cloud.appbroker.deployer.BackingApplication;
+import org.springframework.cloud.appbroker.deployer.BackingApplications;
+import org.springframework.cloud.appbroker.deployer.BackingService;
+import org.springframework.cloud.appbroker.deployer.BackingServices;
+import org.springframework.cloud.appbroker.deployer.BrokeredService;
+import org.springframework.cloud.appbroker.deployer.BrokeredServices;
 import org.springframework.cloud.servicebroker.model.catalog.Plan;
 import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
 
@@ -67,11 +72,6 @@ class AppDeploymentInstanceWorkflowTest {
 			.build();
 
 		workflow = new AppDeploymentInstanceWorkflow(brokeredServices);
-	}
-
-	@Test
-	void acceptWithNoBrokeredAppAndMatchingService() {
-
 	}
 
 	@Test

--- a/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/CreateInstanceWithOnlyABackingServiceComponentTest.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/CreateInstanceWithOnlyABackingServiceComponentTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.integration;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.appbroker.integration.fixtures.CloudControllerStubFixture;
+import org.springframework.cloud.appbroker.integration.fixtures.OpenServiceBrokerApiFixture;
+import org.springframework.cloud.servicebroker.model.instance.OperationState;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.TestPropertySource;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.cloud.appbroker.integration.CreateInstanceWithServicesComponentTest.BACKING_SERVICE_NAME;
+import static org.springframework.cloud.appbroker.integration.CreateInstanceWithServicesComponentTest.BACKING_SI_NAME;
+
+@TestPropertySource(properties = {
+	"spring.cloud.appbroker.services[0].service-name=example",
+	"spring.cloud.appbroker.services[0].plan-name=standard",
+	"spring.cloud.appbroker.services[0].services[0].service-instance-name=" + BACKING_SI_NAME,
+	"spring.cloud.appbroker.services[0].services[0].name=" + BACKING_SERVICE_NAME,
+	"spring.cloud.appbroker.services[0].services[0].plan=standard"
+})
+class CreateInstanceWithOnlyABackingServiceComponentTest extends WiremockComponentTest {
+
+	protected static final String APP_NAME = "app-with-new-services";
+
+	protected static final String BACKING_SI_NAME = "my-db-service";
+
+	protected static final String BACKING_SERVICE_NAME = "db-service";
+
+	@Autowired
+	private OpenServiceBrokerApiFixture brokerFixture;
+
+	@Autowired
+	private CloudControllerStubFixture cloudControllerFixture;
+
+	@Test
+	void createsServicesWhenOnlyBackingServiceIsRequested() {
+
+		// given services are available in the marketplace
+		cloudControllerFixture.stubServiceExists(BACKING_SERVICE_NAME);
+
+		// will create the service instance
+		cloudControllerFixture.stubCreateServiceInstance(BACKING_SI_NAME);
+
+		// when a service instance is created
+		given(brokerFixture.serviceInstanceRequest())
+			.when()
+			.put(brokerFixture.createServiceInstanceUrl(), "instance-id")
+			.then()
+			.statusCode(HttpStatus.ACCEPTED.value());
+
+		// when the "last_operation" API is polled
+		given(brokerFixture.serviceInstanceRequest())
+			.when()
+			.get(brokerFixture.getLastInstanceOperationUrl(), "instance-id")
+			.then()
+			.statusCode(HttpStatus.OK.value())
+			.body("state", is(equalTo(OperationState.IN_PROGRESS.toString())));
+
+		String state = brokerFixture.waitForAsyncOperationComplete("instance-id");
+		assertThat(state).isEqualTo(OperationState.SUCCEEDED.toString());
+	}
+
+}


### PR DESCRIPTION
As discussed in https://github.com/spring-cloud/spring-cloud-app-broker/issues/285, this PR provides the ability to exposed a brokered services which has backing services but not backing applications.