### PR TITLE
Configurable API polling duration to support async backing services

### DIFF
--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployer.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployer.java
@@ -975,6 +975,7 @@ public class CloudFoundryAppDeployer implements AppDeployer, ResourceLoaderAware
 				.serviceName(request.getName())
 				.planName(request.getPlan())
 				.parameters(request.getParameters())
+				.completionTimeout(Duration.ofSeconds(this.defaultDeploymentProperties.getApiPollingTimeout()))
 				.build();
 
 		Mono<CreateServiceInstanceResponse> createServiceInstanceResponseMono =
@@ -1037,6 +1038,7 @@ public class CloudFoundryAppDeployer implements AppDeployer, ResourceLoaderAware
 			org.cloudfoundry.operations.services.DeleteServiceInstanceRequest
 				.builder()
 				.name(serviceInstanceName)
+				.completionTimeout(Duration.ofSeconds(this.defaultDeploymentProperties.getApiPollingTimeout()))
 				.build())
 			.doOnError(exception -> LOG.debug(String.format("Error deleting service instance %s with error '%s'",
 				serviceInstanceName, exception.getMessage()), exception))
@@ -1108,6 +1110,7 @@ public class CloudFoundryAppDeployer implements AppDeployer, ResourceLoaderAware
 		return cloudFoundryOperations.services().updateInstance(
 			org.cloudfoundry.operations.services.UpdateServiceInstanceRequest.builder()
 				.serviceInstanceName(serviceInstanceName)
+				.completionTimeout(Duration.ofSeconds(this.defaultDeploymentProperties.getApiPollingTimeout()))
 				.parameters(request.getParameters())
 				.build())
 			.then(Mono.just(UpdateServiceInstanceResponse.builder()

--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployer.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployer.java
@@ -796,6 +796,13 @@ public class CloudFoundryAppDeployer implements AppDeployer, ResourceLoaderAware
 			.orElse(this.defaultDeploymentProperties.getHealthCheckTimeout());
 	}
 
+	private Duration apiPollingTimeout(Map<String, String> properties) {
+		return Duration.ofSeconds(
+			Optional.ofNullable(properties.get(CloudFoundryDeploymentProperties.API_POLLING_TIMEOUT_PROPERTY_KEY))
+			.map(Long::parseLong)
+			.orElse(this.defaultDeploymentProperties.getApiPollingTimeout()));
+	}
+
 	private Integer instances(Map<String, String> properties) {
 		return Optional.ofNullable(properties.get(DeploymentProperties.COUNT_PROPERTY_KEY))
 			.map(Integer::parseInt)
@@ -975,7 +982,7 @@ public class CloudFoundryAppDeployer implements AppDeployer, ResourceLoaderAware
 				.serviceName(request.getName())
 				.planName(request.getPlan())
 				.parameters(request.getParameters())
-				.completionTimeout(Duration.ofSeconds(this.defaultDeploymentProperties.getApiPollingTimeout()))
+				.completionTimeout(apiPollingTimeout(request.getProperties()))
 				.build();
 
 		Mono<CreateServiceInstanceResponse> createServiceInstanceResponseMono =
@@ -1016,12 +1023,12 @@ public class CloudFoundryAppDeployer implements AppDeployer, ResourceLoaderAware
 			String space = deploymentProperties.get(DeploymentProperties.TARGET_PROPERTY_KEY);
 			requestDeleteServiceInstance = operationsUtils.getOperations(deploymentProperties)
 				.flatMap(cfOperations -> unbindServiceInstance(serviceInstanceName, cfOperations)
-					.then(deleteServiceInstance(serviceInstanceName, cfOperations)))
+					.then(deleteServiceInstance(serviceInstanceName, cfOperations, deploymentProperties)))
 				.then(deleteSpace(space));
 		}
 		else {
 			requestDeleteServiceInstance = unbindServiceInstance(serviceInstanceName, operations)
-				.then(deleteServiceInstance(serviceInstanceName, operations));
+				.then(deleteServiceInstance(serviceInstanceName, operations, deploymentProperties));
 		}
 
 		return requestDeleteServiceInstance
@@ -1033,12 +1040,13 @@ public class CloudFoundryAppDeployer implements AppDeployer, ResourceLoaderAware
 	}
 
 	private Mono<Void> deleteServiceInstance(String serviceInstanceName,
-		CloudFoundryOperations cloudFoundryOperations) {
+		CloudFoundryOperations cloudFoundryOperations,
+		Map<String, String> deploymentProperties) {
 		return cloudFoundryOperations.services().deleteInstance(
 			org.cloudfoundry.operations.services.DeleteServiceInstanceRequest
 				.builder()
 				.name(serviceInstanceName)
-				.completionTimeout(Duration.ofSeconds(this.defaultDeploymentProperties.getApiPollingTimeout()))
+				.completionTimeout(apiPollingTimeout(deploymentProperties))
 				.build())
 			.doOnError(exception -> LOG.debug(String.format("Error deleting service instance %s with error '%s'",
 				serviceInstanceName, exception.getMessage()), exception))
@@ -1110,7 +1118,7 @@ public class CloudFoundryAppDeployer implements AppDeployer, ResourceLoaderAware
 		return cloudFoundryOperations.services().updateInstance(
 			org.cloudfoundry.operations.services.UpdateServiceInstanceRequest.builder()
 				.serviceInstanceName(serviceInstanceName)
-				.completionTimeout(Duration.ofSeconds(this.defaultDeploymentProperties.getApiPollingTimeout()))
+				.completionTimeout(apiPollingTimeout(request.getProperties()))
 				.parameters(request.getParameters())
 				.build())
 			.then(Mono.just(UpdateServiceInstanceResponse.builder()

--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryDeploymentProperties.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryDeploymentProperties.java
@@ -90,6 +90,8 @@ public class CloudFoundryDeploymentProperties extends DeploymentProperties {
 	 */
 	protected static final String JAVA_OPTS_PROPERTY_KEY = "javaOpts";
 
+	public static final long DEFAULT_API_POLLING_TIMEOUT_SECONDS = Duration.ofMinutes(5).getSeconds(); // Default in cf-java-client when no completionTimeout is specified in CSI/USI/DSI
+
 	/**
 	 * The domain to use when mapping routes for applications.
 	 */
@@ -131,9 +133,14 @@ public class CloudFoundryDeploymentProperties extends DeploymentProperties {
 	private boolean enableRandomAppNamePrefix = true;
 
 	/**
-	 * Timeout for blocking API calls, in seconds.
+	 * Timeout for blocking CF API calls, in seconds.
 	 */
 	private long apiTimeout = 360L;
+
+	/**
+	 * Timeout for polled async CF API calls, in seconds. Named "completionTimeout" in cf-java-client
+	 */
+	private long apiPollingTimeout = DEFAULT_API_POLLING_TIMEOUT_SECONDS;
 
 	/**
 	 * Timeout for name API operations in milliseconds
@@ -268,5 +275,14 @@ public class CloudFoundryDeploymentProperties extends DeploymentProperties {
 	public void setJavaOpts(String javaOpts) {
 		this.javaOpts = javaOpts;
 	}
+
+	public long getApiPollingTimeout() {
+		return apiPollingTimeout;
+	}
+
+	public void setApiPollingTimeout(long apiPollingTimeout) {
+		this.apiPollingTimeout = apiPollingTimeout;
+	}
+
 
 }

--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryDeploymentProperties.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryDeploymentProperties.java
@@ -95,6 +95,10 @@ public class CloudFoundryDeploymentProperties extends DeploymentProperties {
 	 */
 	protected static final String JAVA_OPTS_PROPERTY_KEY = "javaOpts";
 
+	/**
+	 * The default value for the  {@link #apiPollingTimeout} property.
+	 * Useful in unit tests to assert default value when not assigned specifically.
+	 */
 	public static final long DEFAULT_API_POLLING_TIMEOUT_SECONDS = Duration.ofMinutes(5).getSeconds();
 
 	/**

--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryDeploymentProperties.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryDeploymentProperties.java
@@ -51,6 +51,11 @@ public class CloudFoundryDeploymentProperties extends DeploymentProperties {
 	protected static final String HEALTHCHECK_TIMEOUT_PROPERTY_KEY = "health-check-timeout";
 
 	/**
+	 * Key for storing the api completion timeout property in seconds.
+	 */
+	protected static final String API_POLLING_TIMEOUT_PROPERTY_KEY = "api-polling-timeout";
+
+	/**
 	 * Key for storing the route path deployment property
 	 */
 	protected static final String ROUTE_PATH_PROPERTY = "route-path";
@@ -90,7 +95,7 @@ public class CloudFoundryDeploymentProperties extends DeploymentProperties {
 	 */
 	protected static final String JAVA_OPTS_PROPERTY_KEY = "javaOpts";
 
-	public static final long DEFAULT_API_POLLING_TIMEOUT_SECONDS = Duration.ofMinutes(5).getSeconds(); // Default in cf-java-client when no completionTimeout is specified in CSI/USI/DSI
+	public static final long DEFAULT_API_POLLING_TIMEOUT_SECONDS = Duration.ofMinutes(5).getSeconds();
 
 	/**
 	 * The domain to use when mapping routes for applications.

--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/test/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployerTest.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/test/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployerTest.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.appbroker.deployer.cloudfoundry;
 
 import java.io.File;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Map;
 
@@ -95,6 +96,7 @@ class CloudFoundryAppDeployerTest {
 	private static final String APP_PATH = "test.jar";
 
 	private static final String SERVICE_INSTANCE_ID = "service-instance-id";
+	private static final long EXPECTED_COMPLETION_DURATION = Duration.ofHours(4L).getSeconds();
 
 	private static final int EXPECTED_MANIFESTS = 1;
 
@@ -138,6 +140,7 @@ class CloudFoundryAppDeployerTest {
 	@BeforeEach
 	void setUp() {
 		deploymentProperties = new CloudFoundryDeploymentProperties();
+		deploymentProperties.setApiPollingTimeout(EXPECTED_COMPLETION_DURATION); //set a different value than the default to make sure it gets loaded
 		CloudFoundryTargetProperties targetProperties = new CloudFoundryTargetProperties();
 		targetProperties.setDefaultOrg("default-org");
 		targetProperties.setDefaultSpace("default-space");
@@ -444,7 +447,8 @@ class CloudFoundryAppDeployerTest {
 		given(operationsServices.deleteInstance(
 			org.cloudfoundry.operations.services.DeleteServiceInstanceRequest.builder()
 				.name("service-instance-name")
-				.build()))
+				.completionTimeout(Duration.ofSeconds(EXPECTED_COMPLETION_DURATION))
+																			 .build()))
 			.willReturn(Mono.empty());
 
 		given(operationsServices.getInstance(GetServiceInstanceRequest.builder().name("service-instance-name").build()))
@@ -485,7 +489,8 @@ class CloudFoundryAppDeployerTest {
 		given(operationsServices.deleteInstance(
 			org.cloudfoundry.operations.services.DeleteServiceInstanceRequest.builder()
 				.name("service-instance-name")
-				.build()))
+				.completionTimeout(Duration.ofSeconds(EXPECTED_COMPLETION_DURATION))
+																			 .build()))
 			.willReturn(Mono.empty());
 
 		given(operationsServices.getInstance(GetServiceInstanceRequest.builder().name("service-instance-name").build()))
@@ -581,7 +586,8 @@ class CloudFoundryAppDeployerTest {
 				.serviceInstanceName("service-instance-name")
 				.serviceName("db-service")
 				.planName("standard")
-				.parameters(emptyMap())
+				.completionTimeout(Duration.ofSeconds(EXPECTED_COMPLETION_DURATION))
+																			 .parameters(emptyMap())
 				.build()))
 			.willReturn(Mono.empty());
 
@@ -649,6 +655,7 @@ class CloudFoundryAppDeployerTest {
 					.serviceInstanceName("service-instance-name")
 					.serviceName("db-service")
 					.planName("standard")
+					.completionTimeout(Duration.ofSeconds(EXPECTED_COMPLETION_DURATION))
 					.parameters(emptyMap())
 					.build()))
 			.willReturn(Mono.empty());
@@ -677,6 +684,7 @@ class CloudFoundryAppDeployerTest {
 			org.cloudfoundry.operations.services.UpdateServiceInstanceRequest.builder()
 				.serviceInstanceName("service-instance-name")
 				.parameters(parameters)
+				.completionTimeout(Duration.ofSeconds(EXPECTED_COMPLETION_DURATION))
 				.build()))
 			.willReturn(Mono.empty());
 
@@ -698,6 +706,7 @@ class CloudFoundryAppDeployerTest {
 			org.cloudfoundry.operations.services.UpdateServiceInstanceRequest.builder()
 				.serviceInstanceName("service-instance-name")
 				.parameters(emptyMap())
+				.completionTimeout(Duration.ofSeconds(EXPECTED_COMPLETION_DURATION))
 				.build()))
 			.willReturn(Mono.empty());
 

--- a/spring-cloud-app-broker-docs/src/docs/asciidoc/service-instances.adoc
+++ b/spring-cloud-app-broker-docs/src/docs/asciidoc/service-instances.adoc
@@ -29,6 +29,7 @@ spring:
             *health-check: http*
             *health-check-http-endpoint: /health*
             *health-check-timeout: 180*
+            *api-polling-timeout: 300*
 ```
 
 Set overriding values for a specific service in the service's configuration under `spring.cloud.appbroker.services.*`, as shown in the following example:
@@ -105,6 +106,10 @@ The following table lists properties that can be set for all or specific app dep
 |`api-timeout`
 |The timeout value used for blocking API calls, in seconds.
 |`360`
+
+|`api-polling-timeout`
+|The timeout value used for polling asynchronous API endpoints (e.g. CF create/update/delete service instance), in seconds.
+|`300`
 
 |`status-timeout`
 |


### PR DESCRIPTION
By default cf-java-client will set a default completion timeout of 5 Mins.

The api-polling-timeout property now enables a configureable value
applied in create/update/delete service instance CF API calls for
backing services.

See https://github.com/spring-cloud/spring-cloud-app-broker/issues/285 for more background on related use-case