### PR TITLE
Support for brokered service plan update

### DIFF
--- a/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfiguration.java
+++ b/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfiguration.java
@@ -67,6 +67,7 @@ import org.springframework.cloud.appbroker.state.ServiceInstanceStateRepository;
 import org.springframework.cloud.appbroker.workflow.instance.AppDeploymentCreateServiceInstanceWorkflow;
 import org.springframework.cloud.appbroker.workflow.instance.AppDeploymentDeleteServiceInstanceWorkflow;
 import org.springframework.cloud.appbroker.workflow.instance.AppDeploymentUpdateServiceInstanceWorkflow;
+import org.springframework.cloud.appbroker.workflow.instance.BackingServicesUpdateValidatorService;
 import org.springframework.cloud.servicebroker.service.ServiceInstanceBindingService;
 import org.springframework.cloud.servicebroker.service.ServiceInstanceService;
 import org.springframework.context.annotation.Bean;
@@ -341,23 +342,22 @@ public class AppBrokerAutoConfiguration {
 	}
 
 	/**
-	 * Provide a {@link UpdateServiceInstanceWorkflow} bean
-	 *
-	 * @param brokeredServices the BrokeredServices bean
-	 * @param backingAppDeploymentService the BackingAppDeploymentService bean
-	 * @param backingServicesProvisionService the BackingServicesProvisionService bean
-	 * @param appsParametersTransformationService the BackingApplicationsParametersTransformationService bean
-	 * @param servicesParametersTransformationService the BackingServicesParametersTransformationService bean
-	 * @param targetService the TargetService bean
+	 * Provide a {@link BackingServicesUpdateValidatorService} bean
 	 * @return the bean
 	 */
+	@Bean
+	public BackingServicesUpdateValidatorService backingServicesUpdateValidatorService() {
+		return new BackingServicesUpdateValidatorService();
+	}
+
 	@Bean
 	public UpdateServiceInstanceWorkflow appDeploymentUpdateServiceInstanceWorkflow(
 		BrokeredServices brokeredServices, BackingAppDeploymentService backingAppDeploymentService,
 		BackingServicesProvisionService backingServicesProvisionService,
 		BackingApplicationsParametersTransformationService appsParametersTransformationService,
 		BackingServicesParametersTransformationService servicesParametersTransformationService,
-		TargetService targetService) {
+		TargetService targetService,
+		BackingServicesUpdateValidatorService backingServicesUpdateValidatorService) {
 
 		return new AppDeploymentUpdateServiceInstanceWorkflow(
 			brokeredServices,
@@ -365,7 +365,7 @@ public class AppBrokerAutoConfiguration {
 			backingServicesProvisionService,
 			appsParametersTransformationService,
 			servicesParametersTransformationService,
-			targetService);
+			targetService, backingServicesUpdateValidatorService);
 	}
 
 	/**

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/BackingService.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/BackingService.java
@@ -29,11 +29,11 @@ public class BackingService {
 
 	private String serviceInstanceName;
 
-	private String name; // a service definition
+	private String name;
 
 	private String plan;
 
-	private String previousPlan; // Necessary to trigger update on plan mutation.
+	private String previousPlan;
 
 	private Map<String, Object> parameters;
 
@@ -132,10 +132,6 @@ public class BackingService {
 		this.rebindOnUpdate = rebindOnUpdate;
 	}
 
-	/**
-	 * Returns the requested updated plan if any. This enables to not trigger backing service when no plan update was
-	 * requested.
-	 */
 	public String getUpdatedPlanIfAny() {
 		if (getPlan() == null) {
 			return null; //should only happen in incomplete unit tests
@@ -145,7 +141,7 @@ public class BackingService {
 		if (planWasUpdated) {
 			return getPlan();
 		}
-		return null;
+		return null; //Don't trigger backing service update when no plan update was requested.
 	}
 
 	@Override

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/BackingService.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/BackingService.java
@@ -29,9 +29,11 @@ public class BackingService {
 
 	private String serviceInstanceName;
 
-	private String name;
+	private String name; // a service definition
 
 	private String plan;
+
+	private String previousPlan; // Necessary to trigger update on plan mutation.
 
 	private Map<String, Object> parameters;
 
@@ -47,6 +49,7 @@ public class BackingService {
 	public BackingService(String serviceInstanceName,
 		String name,
 		String plan,
+		String previousPlan,
 		Map<String, Object> parameters,
 		Map<String, String> properties,
 		List<ParametersTransformerSpec> parametersTransformers,
@@ -54,6 +57,7 @@ public class BackingService {
 		this.serviceInstanceName = serviceInstanceName;
 		this.name = name;
 		this.plan = plan;
+		this.previousPlan = previousPlan;
 		this.parameters = parameters;
 		this.properties = properties;
 		this.parametersTransformers = parametersTransformers;
@@ -82,6 +86,14 @@ public class BackingService {
 
 	public void setPlan(String plan) {
 		this.plan = plan;
+	}
+
+	public String getPreviousPlan() {
+		return previousPlan;
+	}
+
+	public void setPreviousPlan(String previousPlan) {
+		this.previousPlan = previousPlan;
 	}
 
 	public Map<String, Object> getParameters() {
@@ -120,6 +132,22 @@ public class BackingService {
 		this.rebindOnUpdate = rebindOnUpdate;
 	}
 
+	/**
+	 * Returns the requested updated plan if any. This enables to not trigger backing service when no plan update was
+	 * requested.
+	 */
+	public String getUpdatedPlanIfAny() {
+		if (getPlan() == null) {
+			return null; //should only happen in incomplete unit tests
+		}
+
+		boolean planWasUpdated = getPreviousPlan() != null && !getPlan().equals(getPreviousPlan());
+		if (planWasUpdated) {
+			return getPlan();
+		}
+		return null;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
@@ -132,6 +160,7 @@ public class BackingService {
 		return Objects.equals(serviceInstanceName, that.serviceInstanceName) &&
 			Objects.equals(name, that.name) &&
 			Objects.equals(plan, that.plan) &&
+			Objects.equals(previousPlan, that.previousPlan) &&
 			Objects.equals(parameters, that.parameters) &&
 			Objects.equals(properties, that.properties) &&
 			Objects.equals(parametersTransformers, that.parametersTransformers) &&
@@ -141,7 +170,8 @@ public class BackingService {
 	@Override
 	public int hashCode() {
 		return Objects
-			.hash(serviceInstanceName, name, plan, parameters, properties, parametersTransformers, rebindOnUpdate);
+			.hash(serviceInstanceName, name, plan, previousPlan, parameters, properties, parametersTransformers,
+				rebindOnUpdate);
 	}
 
 	@Override
@@ -150,6 +180,7 @@ public class BackingService {
 			"serviceInstanceName='" + serviceInstanceName + '\'' +
 			", name='" + name + '\'' +
 			", plan='" + plan + '\'' +
+			", previousPlan='" + previousPlan + '\'' +
 			", parameters=" + parameters +
 			", properties=" + properties +
 			", parametersTransformers=" + parametersTransformers +
@@ -169,6 +200,8 @@ public class BackingService {
 
 		private String plan;
 
+		private String previousPlan;
+
 		private final Map<String, Object> parameters = new HashMap<>();
 
 		private final Map<String, String> properties = new HashMap<>();
@@ -184,6 +217,7 @@ public class BackingService {
 			return this.serviceInstanceName(backingService.getServiceInstanceName())
 				.name(backingService.getName())
 				.plan(backingService.getPlan())
+				.previousPlan(backingService.getPreviousPlan())
 				.parameters(backingService.getParameters())
 				.properties(backingService.getProperties())
 				.parameterTransformers(backingService.getParametersTransformers())
@@ -202,6 +236,11 @@ public class BackingService {
 
 		public BackingServiceBuilder plan(String plan) {
 			this.plan = plan;
+			return this;
+		}
+
+		public BackingServiceBuilder previousPlan(String previousPlan) {
+			this.previousPlan = previousPlan;
 			return this;
 		}
 
@@ -239,7 +278,8 @@ public class BackingService {
 		}
 
 		public BackingService build() {
-			return new BackingService(serviceInstanceName, name, plan, parameters, properties, parameterTransformers,
+			return new BackingService(serviceInstanceName, name, plan, previousPlan, parameters, properties,
+				parameterTransformers,
 				rebindOnUpdate);
 		}
 

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/DeployerClient.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/DeployerClient.java
@@ -113,6 +113,7 @@ public class DeployerClient {
 				UpdateServiceInstanceRequest
 					.builder()
 					.serviceInstanceName(backingService.getServiceInstanceName())
+					.plan(backingService.getUpdatedPlanIfAny())
 					.parameters(backingService.getParameters())
 					.properties(backingService.getProperties())
 					.rebindOnUpdate(backingService.isRebindOnUpdate())

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/BackingServicesUpdateValidatorService.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/BackingServicesUpdateValidatorService.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.workflow.instance;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import reactor.core.publisher.Mono;
+
+import org.springframework.cloud.appbroker.deployer.BackingService;
+
+/**
+ * Validates updates to backing services, and returns an updated copy of the list with the previousPlan set. This help
+ * only triggering plan update when previousPlan is set.
+ */
+public class BackingServicesUpdateValidatorService {
+
+	// Accept and return Mono to make it easier for AppDeploymentUpdateServiceInstanceWorkflow to provide us with previous and candidate backing services
+	public Mono<List<BackingService>> validatePlanUpdate(Mono<List<BackingService>> previousBackingServices,
+		Mono<List<BackingService>> candidateBackingServicesForUpdate) {
+		try {
+			return Mono.just(validateAndMutatePlanUpdate(previousBackingServices.block(),
+				candidateBackingServicesForUpdate.block()));
+		}
+		catch (IllegalArgumentException e) {
+			return Mono.error(e);
+		}
+	}
+
+	public List<BackingService> validateAndMutatePlanUpdate(List<BackingService> previousBackingServicesList,
+		List<BackingService> candidateBackingServicesList) {
+		return candidateBackingServicesList.stream()
+			.map(candidateBackingService -> {
+				BackingService matchingPreviousBackingService = getValidatedBackingService(candidateBackingService,
+					previousBackingServicesList);
+				if (candidateBackingService.getPlan().equals(matchingPreviousBackingService.getPlan())) {
+					return candidateBackingService;
+				}
+				else {
+					//Don't mutate the caller's BackingService, return a copy instead.
+					return BackingService.builder()
+						.backingService(candidateBackingService)
+						.previousPlan(matchingPreviousBackingService.getPlan())
+						.build();
+				}
+
+			})
+			.collect(Collectors.toList());
+	}
+
+	private BackingService getValidatedBackingService(BackingService candidate,
+		List<BackingService> previousBackingServicesList) {
+		List<BackingService> matchingPreviousBackingServices = previousBackingServicesList.stream()
+			.filter(previousBackingService ->
+				previousBackingService.getName().equals(candidate.getName()) &&
+					previousBackingService.getServiceInstanceName().equals(candidate.getServiceInstanceName()))
+			.collect(Collectors.toList());
+		if (matchingPreviousBackingServices.size() != 1) { // NOPMD
+			throw new IllegalArgumentException(
+				"Unsupported update that would result into backing services changes other than plan ugrade. Candidate after update= " + candidate + " Before update=" + previousBackingServicesList);
+		}
+		return matchingPreviousBackingServices.get(0);
+	}
+
+}

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/workflow/instance/BackingServicesUpdateValidatorServiceTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/workflow/instance/BackingServicesUpdateValidatorServiceTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.workflow.instance;
+
+import java.util.List;
+
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import org.springframework.cloud.appbroker.deployer.BackingService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class BackingServicesUpdateValidatorServiceTest {
+
+	private final BackingServicesUpdateValidatorService backingServicesUpdateValidatorService = new BackingServicesUpdateValidatorService();
+
+	private BackingService mysql;
+
+	private BackingService postgresql;
+
+	@BeforeEach
+	void setUp() {
+		mysql = BackingService
+			.builder()
+			.name("mysql")
+			.plan("10mb")
+			.serviceInstanceName("my-mysql-service-instance")
+			.build();
+		postgresql = BackingService
+			.builder()
+			.name("postgresql")
+			.plan("a-plan")
+			.serviceInstanceName("my-pg-service-instance")
+			.build();
+	}
+
+	@Test
+	void emitsAnErrorWhenRejected() {
+		//Given a rejected case (tested in "rejectsWhenNewBackingServicesCreated")
+		Mono<List<BackingService>> requestedBackingServices = backingServicesUpdateValidatorService.validatePlanUpdate(
+			Mono.just(Lists.newArrayList(mysql)),
+			Mono.just(Lists.newArrayList(mysql, postgresql))
+		);
+
+		StepVerifier.create(requestedBackingServices)
+			//then
+			.expectError(IllegalArgumentException.class)
+			.verify();
+	}
+
+	@Test
+	void validatesWhenNoChanges() {
+		List<BackingService> validatedServices = backingServicesUpdateValidatorService.validateAndMutatePlanUpdate(
+			Lists.newArrayList(mysql),
+			Lists.newArrayList(mysql));
+		assertThat(validatedServices).isEqualTo(Lists.newArrayList(mysql));
+	}
+
+	@Test
+	void validatesAndSetPreviousPlanWhenPlanUpdates() {
+		//given
+		BackingService mysql10Mb = BackingService
+			.builder()
+			.name("mysql")
+			.plan("10mb")
+			.serviceInstanceName("my-service-instance")
+			.build();
+		BackingService mysql100Mb = BackingService
+			.builder()
+			.name("mysql")
+			.plan("100mb")
+			.serviceInstanceName("my-service-instance")
+			.build();
+
+		//when
+		List<BackingService> validatedServices = backingServicesUpdateValidatorService.validateAndMutatePlanUpdate(
+			Lists.newArrayList(mysql10Mb),
+			Lists.newArrayList(mysql100Mb));
+
+		//Then
+		BackingService mysql100MbWithPreviousPlan = BackingService
+			.builder()
+			.name("mysql")
+			.plan("100mb")
+			.previousPlan("10mb")
+			.serviceInstanceName("my-service-instance")
+			.build();
+		assertThat(validatedServices).isEqualTo(Lists.newArrayList(mysql100MbWithPreviousPlan));
+
+	}
+
+	@Test
+	void rejectsWhenNewBackingServicesCreated() {
+		assertThrows(Exception.class, () -> backingServicesUpdateValidatorService.validateAndMutatePlanUpdate(
+			Lists.newArrayList(mysql),
+			Lists.newArrayList(mysql, postgresql)));
+	}
+
+	@Test
+	void rejectsWhenChangesType() {
+		BackingService mysql = BackingService
+			.builder()
+			.name("mysql")
+			.plan("10mb")
+			.serviceInstanceName("my-service-instance")
+			.build();
+		BackingService pg = BackingService
+			.builder()
+			.name("postgresql")
+			.plan("10mb")
+			.serviceInstanceName("my-service-instance")
+			.build();
+		assertThrows(Exception.class, () -> backingServicesUpdateValidatorService.validateAndMutatePlanUpdate(
+			Lists.newArrayList(mysql),
+			Lists.newArrayList(pg)));
+	}
+
+	@Test
+	void rejectsWhenChangeServiceInstanceName() {
+		BackingService mysql = BackingService
+			.builder()
+			.name("mysql")
+			.plan("10mb")
+			.serviceInstanceName("my-service-instance")
+			.build();
+		BackingService pg = BackingService
+			.builder()
+			.name("mysql")
+			.plan("10mb")
+			.serviceInstanceName("my-unrelated-service-instance")
+			.build();
+		assertThrows(Exception.class, () -> backingServicesUpdateValidatorService.validateAndMutatePlanUpdate(
+			Lists.newArrayList(mysql),
+			Lists.newArrayList(pg)));
+	}
+
+}

--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/test/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployerTest.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/test/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployerTest.java
@@ -681,7 +681,7 @@ class CloudFoundryAppDeployerTest {
 	}
 
 	@Test
-	void updateServiceInstanceUpdatesWithParameters() {
+	void updateServiceInstanceUpdatesWithParametersUpdatesBackingServices() {
 		Map<String, Object> parameters = singletonMap("param1", "value");
 
 		given(operationsServices.updateInstance(
@@ -705,7 +705,7 @@ class CloudFoundryAppDeployerTest {
 	}
 
 	@Test
-	void updateServiceInstanceRebindsWhenRequired() {
+	void updateServiceInstanceRebindsBackingAppWhenRequired() {
 		given(operationsServices.updateInstance(
 			org.cloudfoundry.operations.services.UpdateServiceInstanceRequest.builder()
 				.serviceInstanceName("service-instance-name")
@@ -761,7 +761,7 @@ class CloudFoundryAppDeployerTest {
 	}
 
 	@Test
-	void updateServiceInstanceDoesNothingWithoutParameters() {
+	void updateServiceInstanceDoesNothingWithoutParametersNorPlan() {
 		given(operationsServices.updateInstance(
 			org.cloudfoundry.operations.services.UpdateServiceInstanceRequest.builder()
 				.serviceInstanceName("service-instance-name")
@@ -777,6 +777,29 @@ class CloudFoundryAppDeployerTest {
 
 		StepVerifier.create(
 			appDeployer.updateServiceInstance(request))
+			.verifyComplete();
+	}
+
+
+	@Test
+	void updateServiceInstanceWithPlanUpdatesBackingService() {
+		given(operationsServices.updateInstance(
+			org.cloudfoundry.operations.services.UpdateServiceInstanceRequest.builder()
+				.serviceInstanceName("service-instance-name")
+				.planName("premium")
+				.build()))
+			.willReturn(Mono.empty());
+
+		UpdateServiceInstanceRequest request =
+			UpdateServiceInstanceRequest.builder()
+				.serviceInstanceName("service-instance-name")
+				.parameters(emptyMap())
+				.plan("premium")
+				.build();
+
+		StepVerifier.create(
+			appDeployer.updateServiceInstance(request))
+			.assertNext(response -> assertThat(response.getName()).isEqualTo("service-instance-name"))
 			.verifyComplete();
 	}
 

--- a/spring-cloud-app-broker-deployer/src/main/java/org/springframework/cloud/appbroker/deployer/AppDeployer.java
+++ b/spring-cloud-app-broker-deployer/src/main/java/org/springframework/cloud/appbroker/deployer/AppDeployer.java
@@ -40,6 +40,10 @@ public interface AppDeployer {
 		return Mono.empty();
 	}
 
+	/**
+	 * Updates a service instance request
+	 * @return A non-empty UpdateServiceInstanceResponse only if an update was performed
+	 */
 	default Mono<UpdateServiceInstanceResponse> updateServiceInstance(UpdateServiceInstanceRequest request) {
 		return Mono.empty();
 	}

--- a/spring-cloud-app-broker-deployer/src/main/java/org/springframework/cloud/appbroker/deployer/UpdateServiceInstanceRequest.java
+++ b/spring-cloud-app-broker-deployer/src/main/java/org/springframework/cloud/appbroker/deployer/UpdateServiceInstanceRequest.java
@@ -31,14 +31,18 @@ public class UpdateServiceInstanceRequest {
 
 	private final boolean rebindOnUpdate;
 
+	private final String plan;
+
 	protected UpdateServiceInstanceRequest(String serviceInstanceName,
 		Map<String, Object> parameters,
 		Map<String, String> properties,
-		boolean rebindOnUpdate) {
+		boolean rebindOnUpdate,
+		String plan) {
 		this.serviceInstanceName = serviceInstanceName;
 		this.parameters = parameters;
 		this.properties = properties;
 		this.rebindOnUpdate = rebindOnUpdate;
+		this.plan = plan;
 	}
 
 	public static UpdateServiceInstanceRequestBuilder builder() {
@@ -61,6 +65,10 @@ public class UpdateServiceInstanceRequest {
 		return rebindOnUpdate;
 	}
 
+	public String getPlan() {
+		return plan;
+	}
+
 	public static final class UpdateServiceInstanceRequestBuilder {
 
 		private String serviceInstanceName;
@@ -70,6 +78,8 @@ public class UpdateServiceInstanceRequest {
 		private final Map<String, String> properties = new HashMap<>();
 
 		private boolean rebindOnUpdate;
+
+		private String plan;
 
 		private UpdateServiceInstanceRequestBuilder() {
 		}
@@ -93,6 +103,11 @@ public class UpdateServiceInstanceRequest {
 			return this;
 		}
 
+		public UpdateServiceInstanceRequestBuilder plan(String plan) {
+			this.plan = plan;
+			return this;
+		}
+
 		public UpdateServiceInstanceRequestBuilder properties(Map<String, String> properties) {
 			if (!CollectionUtils.isEmpty(properties)) {
 				this.properties.putAll(properties);
@@ -106,7 +121,7 @@ public class UpdateServiceInstanceRequest {
 		}
 
 		public UpdateServiceInstanceRequest build() {
-			return new UpdateServiceInstanceRequest(serviceInstanceName, parameters, properties, rebindOnUpdate);
+			return new UpdateServiceInstanceRequest(serviceInstanceName, parameters, properties, rebindOnUpdate, plan);
 		}
 
 	}


### PR DESCRIPTION
This PR provides ability for a brokered service plan update to cascade the plan update to backing services. See https://github.com/spring-cloud/spring-cloud-app-broker/issues/285 for more background around this use-case.

In the master branch, a brokered service update only triggers a backing service update if params were changed. I understand this is an optimization which avoid extra calls to CF

https://github.com/spring-cloud/spring-cloud-app-broker/blob/c32dd2b103ff691d762af082c30194f1774872b0/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployer.java#L1061-L1066

Initial branch (available at https://github.com/orange-cloudfoundry/osb-cmdb-spike/tree/updateable-plans-not-optimized) discarded the optimization. I started updating the integration tests and failed to update the wiremock stub tests within a reasonable time.

Alternatives considered for preserving the optimization
1. store a previousPlan (String) in BackingService, so that org.springframework.cloud.appbroker.deployer.DeployerClient.updateServiceInstance() can optionally set the plan to non null in org.springframework.cloud.appbroker.deployer.UpdateServiceInstanceRequest
1. fetch backing service instance using [GET /v2/service_instances/:instance_id](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#fetching-a-service-instance) and compare with `UpdateServiceInstanceRequest`. This systematic extra OSB fetch call defeats the optimization.

I then worked to preserve the optimization with approach 1 above