### PR TITLE
SpacePerServicePlan and SpacePerServiceDefinition targets

### DIFF
--- a/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfiguration.java
+++ b/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfiguration.java
@@ -304,16 +304,17 @@ public class AppBrokerAutoConfiguration {
 	}
 
 	/**
-	 * Provide a {@link TargetService} bean
-	 *
-	 * @param targets a collection of targets
-	 * @return the bean
+	 * Provide a {@link SpacePerServicePlan} bean
 	 */
 	@Bean
-	public SpacePerServicePlan spacePerServicePlan() { return new SpacePerServicePlan();}
+	public SpacePerServicePlan spacePerServicePlan() {
+		return new SpacePerServicePlan();
+	}
 
 	@Bean
-	public SpacePerServiceDefinition spacePerServiceDefinition() { return new SpacePerServiceDefinition();}
+	public SpacePerServiceDefinition spacePerServiceDefinition() {
+		return new SpacePerServiceDefinition();
+	}
 
 	@Bean
 	public TargetService targetService(List<TargetFactory<?>> targets) {

--- a/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfiguration.java
+++ b/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfiguration.java
@@ -48,7 +48,9 @@ import org.springframework.cloud.appbroker.extensions.parameters.ParameterMappin
 import org.springframework.cloud.appbroker.extensions.parameters.ParametersTransformerFactory;
 import org.springframework.cloud.appbroker.extensions.parameters.PropertyMappingParametersTransformerFactory;
 import org.springframework.cloud.appbroker.extensions.targets.ServiceInstanceGuidSuffix;
+import org.springframework.cloud.appbroker.extensions.targets.SpacePerServiceDefinition;
 import org.springframework.cloud.appbroker.extensions.targets.SpacePerServiceInstance;
+import org.springframework.cloud.appbroker.extensions.targets.SpacePerServicePlan;
 import org.springframework.cloud.appbroker.extensions.targets.TargetFactory;
 import org.springframework.cloud.appbroker.extensions.targets.TargetService;
 import org.springframework.cloud.appbroker.manager.AppManager;
@@ -307,6 +309,12 @@ public class AppBrokerAutoConfiguration {
 	 * @param targets a collection of targets
 	 * @return the bean
 	 */
+	@Bean
+	public SpacePerServicePlan spacePerServicePlan() { return new SpacePerServicePlan();}
+
+	@Bean
+	public SpacePerServiceDefinition spacePerServiceDefinition() { return new SpacePerServiceDefinition();}
+
 	@Bean
 	public TargetService targetService(List<TargetFactory<?>> targets) {
 		return new TargetService(targets);

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/ServiceInstanceGuidSuffix.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/ServiceInstanceGuidSuffix.java
@@ -33,7 +33,7 @@ public class ServiceInstanceGuidSuffix extends TargetFactory<ServiceInstanceGuid
 		return this::apply;
 	}
 
-	private ArtifactDetails apply(Map<String, String> properties, String name, String serviceInstanceId) {
+	private ArtifactDetails apply(Map<String, String> properties, String name, String serviceInstanceId, String backingServiceName, String backingServicePlanName) {
 		final int availableLength = calculateAvailableLength(serviceInstanceId);
 		String modifiedName = name;
 		if (name.length() > calculateAvailableLength(serviceInstanceId)) {

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/ServiceInstanceGuidSuffix.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/ServiceInstanceGuidSuffix.java
@@ -33,6 +33,7 @@ public class ServiceInstanceGuidSuffix extends TargetFactory<ServiceInstanceGuid
 		return this::apply;
 	}
 
+	@SuppressWarnings("PMD.UnusedFormalParameter")
 	private ArtifactDetails apply(Map<String, String> properties, String name, String serviceInstanceId, String backingServiceName, String backingServicePlanName) {
 		final int availableLength = calculateAvailableLength(serviceInstanceId);
 		String modifiedName = name;

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/SpacePerServiceDefinition.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/SpacePerServiceDefinition.java
@@ -16,9 +16,9 @@
 
 package org.springframework.cloud.appbroker.extensions.targets;
 
-import org.springframework.cloud.appbroker.deployer.DeploymentProperties;
-
 import java.util.Map;
+
+import org.springframework.cloud.appbroker.deployer.DeploymentProperties;
 
 public class SpacePerServiceDefinition extends TargetFactory<SpacePerServiceDefinition.Config> {
 

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/SpacePerServiceDefinition.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/SpacePerServiceDefinition.java
@@ -31,6 +31,7 @@ public class SpacePerServiceDefinition extends TargetFactory<SpacePerServiceDefi
 		return this::apply;
 	}
 
+	@SuppressWarnings("PMD.UnusedFormalParameter")
 	private ArtifactDetails apply(Map<String, String> properties, String name, String brokeredServiceInstanceId, String backingServiceName, String backingServicePlanName) {
 		properties.put(DeploymentProperties.TARGET_PROPERTY_KEY, backingServiceName);
 		properties.put(DeploymentProperties.KEEP_TARGET_ON_DELETE_PROPERTY_KEY, "true");

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/SpacePerServiceDefinition.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/SpacePerServiceDefinition.java
@@ -42,7 +42,7 @@ public class SpacePerServiceDefinition extends TargetFactory<SpacePerServiceDefi
 			.build();
 	}
 
-	static class Config {
+	public static class Config {
 	}
 
 }

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/SpacePerServiceDefinition.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/SpacePerServiceDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@
 
 package org.springframework.cloud.appbroker.extensions.targets;
 
-import java.util.Map;
-
 import org.springframework.cloud.appbroker.deployer.DeploymentProperties;
 
-public class SpacePerServiceInstance extends TargetFactory<SpacePerServiceInstance.Config> {
+import java.util.Map;
 
-	public SpacePerServiceInstance() {
+public class SpacePerServiceDefinition extends TargetFactory<SpacePerServiceDefinition.Config> {
+
+	public SpacePerServiceDefinition() {
 		super(Config.class);
 	}
 
@@ -31,17 +31,17 @@ public class SpacePerServiceInstance extends TargetFactory<SpacePerServiceInstan
 		return this::apply;
 	}
 
-	private ArtifactDetails apply(Map<String, String> properties, String name, String serviceInstanceId, String backingServiceName, String backingServicePlanName) {
-		properties.put(DeploymentProperties.HOST_PROPERTY_KEY, name + "-" + serviceInstanceId);
-		properties.put(DeploymentProperties.TARGET_PROPERTY_KEY, serviceInstanceId);
+	private ArtifactDetails apply(Map<String, String> properties, String name, String brokeredServiceInstanceId, String backingServiceName, String backingServicePlanName) {
+		properties.put(DeploymentProperties.TARGET_PROPERTY_KEY, backingServiceName);
+		properties.put(DeploymentProperties.KEEP_TARGET_ON_DELETE_PROPERTY_KEY, "true");
 
 		return ArtifactDetails.builder()
-			.name(name)
+			.name(name + "-" + brokeredServiceInstanceId)
 			.properties(properties)
 			.build();
 	}
 
-	public static class Config {
+	static class Config {
 	}
 
 }

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/SpacePerServiceInstance.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/SpacePerServiceInstance.java
@@ -31,6 +31,7 @@ public class SpacePerServiceInstance extends TargetFactory<SpacePerServiceInstan
 		return this::apply;
 	}
 
+	@SuppressWarnings("PMD.UnusedFormalParameter")
 	private ArtifactDetails apply(Map<String, String> properties, String name, String serviceInstanceId, String backingServiceName, String backingServicePlanName) {
 		properties.put(DeploymentProperties.HOST_PROPERTY_KEY, name + "-" + serviceInstanceId);
 		properties.put(DeploymentProperties.TARGET_PROPERTY_KEY, serviceInstanceId);

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/SpacePerServicePlan.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/SpacePerServicePlan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@
 
 package org.springframework.cloud.appbroker.extensions.targets;
 
-import java.util.Map;
-
 import org.springframework.cloud.appbroker.deployer.DeploymentProperties;
 
-public class SpacePerServiceInstance extends TargetFactory<SpacePerServiceInstance.Config> {
+import java.util.Map;
 
-	public SpacePerServiceInstance() {
+public class SpacePerServicePlan extends TargetFactory<SpacePerServicePlan.Config> {
+
+	public SpacePerServicePlan() {
 		super(Config.class);
 	}
 
@@ -31,17 +31,17 @@ public class SpacePerServiceInstance extends TargetFactory<SpacePerServiceInstan
 		return this::apply;
 	}
 
-	private ArtifactDetails apply(Map<String, String> properties, String name, String serviceInstanceId, String backingServiceName, String backingServicePlanName) {
-		properties.put(DeploymentProperties.HOST_PROPERTY_KEY, name + "-" + serviceInstanceId);
-		properties.put(DeploymentProperties.TARGET_PROPERTY_KEY, serviceInstanceId);
+	private ArtifactDetails apply(Map<String, String> properties, String name, String brokeredServiceInstanceId, String backingServiceName, String backingServicePlanName) {
+		properties.put(DeploymentProperties.TARGET_PROPERTY_KEY, backingServiceName + "-" + backingServicePlanName);
+		properties.put(DeploymentProperties.KEEP_TARGET_ON_DELETE_PROPERTY_KEY, "true");
 
 		return ArtifactDetails.builder()
-			.name(name)
+			.name(name + "-" + brokeredServiceInstanceId)
 			.properties(properties)
 			.build();
 	}
 
-	public static class Config {
+	static class Config {
 	}
 
 }

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/SpacePerServicePlan.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/SpacePerServicePlan.java
@@ -41,7 +41,7 @@ public class SpacePerServicePlan extends TargetFactory<SpacePerServicePlan.Confi
 			.build();
 	}
 
-	static class Config {
+	public static class Config {
 	}
 
 }

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/SpacePerServicePlan.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/SpacePerServicePlan.java
@@ -16,9 +16,9 @@
 
 package org.springframework.cloud.appbroker.extensions.targets;
 
-import org.springframework.cloud.appbroker.deployer.DeploymentProperties;
-
 import java.util.Map;
+
+import org.springframework.cloud.appbroker.deployer.DeploymentProperties;
 
 public class SpacePerServicePlan extends TargetFactory<SpacePerServicePlan.Config> {
 

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/Target.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/Target.java
@@ -20,6 +20,9 @@ import java.util.Map;
 
 public interface Target {
 
-	ArtifactDetails apply(Map<String, String> properties, String name, String serviceInstanceId);
-
+	/**
+	 * Fetch the {@link ArtifactDetails} for a backing application or backing service.
+	 * @param name backing application name or backing service instance name
+	 */
+	ArtifactDetails apply(Map<String, String> properties, String name, String brokeredServiceInstanceId, String backingServiceName, String backingServicePlanName);
 }

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/TargetService.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/TargetService.java
@@ -42,13 +42,13 @@ public class TargetService {
 			.flatMap(backingApplication -> {
 				if (targetSpec != null) {
 					ArtifactDetails appDetails = getArtifactDetails(targetSpec, serviceInstanceId,
-						backingApplication.getName(), backingApplication.getProperties());
+						backingApplication.getName(), null, null, backingApplication.getProperties());
 					backingApplication.setName(appDetails.getName());
 					backingApplication.setProperties(appDetails.getProperties());
 
 					backingApplication.getServices().forEach(servicesSpec -> {
-						ArtifactDetails serviceDetails = getArtifactDetails(targetSpec, serviceInstanceId,
-							servicesSpec.getServiceInstanceName(), new HashMap<>());
+						ArtifactDetails serviceDetails = getArtifactDetails(targetSpec, serviceInstanceId, servicesSpec.getServiceInstanceName(), null,null,
+							new HashMap<>());
 						servicesSpec.setServiceInstanceName(serviceDetails.getName());
 					});
 				}
@@ -64,7 +64,9 @@ public class TargetService {
 			.flatMap(backingService -> {
 				if (targetSpec != null) {
 					ArtifactDetails serviceDetails = getArtifactDetails(targetSpec, serviceInstanceId,
-						backingService.getServiceInstanceName(), backingService.getProperties());
+						backingService.getServiceInstanceName(), backingService.getName(),
+						backingService.getPlan(),
+						backingService.getProperties());
 					backingService.setServiceInstanceName(serviceDetails.getName());
 					backingService.setProperties(serviceDetails.getProperties());
 				}
@@ -73,10 +75,9 @@ public class TargetService {
 			.collectList();
 	}
 
-	private ArtifactDetails getArtifactDetails(TargetSpec targetSpec, String serviceInstanceId,
-		String name, Map<String, String> properties) {
+	private ArtifactDetails getArtifactDetails(TargetSpec targetSpec, String serviceInstanceId, String serviceInstanceName, String backingServiceName, String backingServicePlanName, Map<String, String> properties) {
 		Target target = locator.getByName(targetSpec.getName());
-		return target.apply(properties, name, serviceInstanceId);
+		return target.apply(properties, serviceInstanceName, serviceInstanceId, backingServiceName, backingServicePlanName);
 	}
 
 }

--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployer.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployer.java
@@ -1081,7 +1081,7 @@ public class CloudFoundryAppDeployer implements AppDeployer, ResourceLoaderAware
 
 		Mono<Void> requestDeleteServiceInstance = operationsUtils.getOperations(deploymentProperties)
 			.flatMap(cfOperations -> unbindServiceInstance(serviceInstanceName, cfOperations)
-				.then(deleteServiceInstance(serviceInstanceName, cfOperations)));
+				.then(deleteServiceInstance(serviceInstanceName, cfOperations, deploymentProperties)));
 
 		if (targetSpace != null && deleteTargetSpace) {
 			requestDeleteServiceInstance = requestDeleteServiceInstance

--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/test/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployerTest.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/test/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployerTest.java
@@ -93,7 +93,7 @@ import static org.springframework.cloud.appbroker.deployer.DeploymentProperties.
 import static org.springframework.cloud.appbroker.deployer.DeploymentProperties.TARGET_PROPERTY_KEY;
 import static org.springframework.cloud.appbroker.deployer.cloudfoundry.CloudFoundryDeploymentProperties.DEFAULT_API_POLLING_TIMEOUT_SECONDS;
 
-@SuppressWarnings("UnassignedFluxMonoInstance")
+@SuppressWarnings({"UnassignedFluxMonoInstance", "PMD.ExcessiveClassLength"})
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class CloudFoundryAppDeployerTest {

--- a/spring-cloud-app-broker-deployer/src/main/java/org/springframework/cloud/appbroker/deployer/DeploymentProperties.java
+++ b/spring-cloud-app-broker-deployer/src/main/java/org/springframework/cloud/appbroker/deployer/DeploymentProperties.java
@@ -58,6 +58,12 @@ public class DeploymentProperties {
 	public static final String TARGET_PROPERTY_KEY = "target";
 
 	/**
+	 * Set to "true" to keep the space (where the app and backing services will be deployed) after brokered service
+	 * is deleted. Defaults to "false" if unspecified.
+	 */
+	public static final String KEEP_TARGET_ON_DELETE_PROPERTY_KEY = "keepTargetSpaceOnDelete";
+
+	/**
 	 * The deployment property indicating whether the application should be automatically started after deployment.
 	 * Defaults to true.
 	 */

--- a/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/CreateInstanceWithCustomTargetComponentTest.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/CreateInstanceWithCustomTargetComponentTest.java
@@ -136,7 +136,8 @@ class CreateInstanceWithCustomTargetComponentTest extends WiremockComponentTest 
 				return this::apply;
 			}
 
-			private ArtifactDetails apply(Map<String, String> properties, String name, String serviceInstanceId) {
+			ArtifactDetails apply(Map<String, String> properties, String name, String brokeredServiceInstanceId,
+				String backingServiceName, String backingServicePlanName) {
 				String space = customSpaceService.retrieveSpaceName();
 				properties.put(DeploymentProperties.TARGET_PROPERTY_KEY, space);
 


### PR DESCRIPTION
This PR add support for targets that create backing services in respectively:
- SpacePerServicePlan 
- SpacePerServiceDefinition 

Since multiple service instances are sharing a dynamically created space, this space is not deleted upon service instance deletion: the CloudFoundryAppDeployer now honors a new key `DeploymentProperties.KEEP_TARGET_ON_DELETE_PROPERTY_KEY` enabling space target to not be deleted upon service instance removal.

This support use-case described into #285 in particular ability for an operator to set CF quotas on spaces hosting backing services in order to restrict number of backing services of a given definition or service plans.


Pending tasks in this pr
* [x] Add unit test for CloudFoundryAppDeployer 
* [ ] Add a component test: CreateInstanceWithOnlyServicesTargetComponentTest inspired from `CreateInstanceWithServicesComponentTest` and `CreateInstanceWithCustomTargetComponentTest` 
* [ ] Add an acceptance test ? Is it worth slowing ATs with this use case ?

Note that this PR misses some updates to service key support (see #292) that currently omited to make the two PRs independent. For the record, they are available at https://github.com/orange-cloudfoundry/osb-cmdb-spike/commit/08390cef44622db08e11adc95ae8d4b2110bc6a2