### PR TITLE
Use Reactive Spring CredHub APIs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ ext {
 	springFrameworkVersion = project.findProperty("springFrameworkVersion") ?: "5.2.2.RELEASE"
 	reactorVersion = project.findProperty("reactorVersion") ?: "Dysprosium-SR2"
 	openServiceBrokerVersion = "3.1.0.RELEASE"
-	springCredhubVersion = "2.0.1.RELEASE"
+	springCredhubVersion = "2.1.0.BUILD-SNAPSHOT"
 	cfJavaClientVersion = "4.2.0.RELEASE"
 	blockHoundVersion = "1.0.1.RELEASE"
 	junitPlatformLauncherVersion = "1.5.2"
@@ -82,6 +82,7 @@ configure(allprojects) {
 	repositories {
 		mavenCentral()
 		maven { url "https://repo.spring.io/libs-release" }
+		maven { url "https://repo.spring.io/libs-snapshot" }
 	}
 
 	dependencies {

--- a/spring-cloud-app-broker-autoconfigure/build.gradle
+++ b/spring-cloud-app-broker-autoconfigure/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 	testImplementation("org.springframework.boot:spring-boot-starter-test") {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 	}
+	testImplementation("org.springframework.boot:spring-boot-starter-webflux")
 	testImplementation("io.projectreactor.tools:blockhound-junit-platform:${blockHoundVersion}")
 }
 

--- a/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/CredHubAutoConfiguration.java
+++ b/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/CredHubAutoConfiguration.java
@@ -29,7 +29,7 @@ import org.springframework.cloud.appbroker.workflow.binding.CredHubPersistingDel
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.credhub.autoconfig.CredHubTemplateAutoConfiguration;
-import org.springframework.credhub.core.CredHubOperations;
+import org.springframework.credhub.core.ReactiveCredHubOperations;
 
 /**
  * CredHub auto-configuration
@@ -37,8 +37,8 @@ import org.springframework.credhub.core.CredHubOperations;
 @Configuration
 @AutoConfigureBefore(AppBrokerAutoConfiguration.class)
 @AutoConfigureAfter(CredHubTemplateAutoConfiguration.class)
-@ConditionalOnClass(CredHubOperations.class)
-@ConditionalOnBean(CredHubOperations.class)
+@ConditionalOnClass(ReactiveCredHubOperations.class)
+@ConditionalOnBean(ReactiveCredHubOperations.class)
 public class CredHubAutoConfiguration {
 
 	@Value("${spring.application.name}")
@@ -47,35 +47,35 @@ public class CredHubAutoConfiguration {
 	/**
 	 * Provide a {@link CreateServiceInstanceAppBindingWorkflow} bean
 	 *
-	 * @param credHubOperations the CredHubOperations bean
+	 * @param credHubOperations the ReactiveCredHubOperations bean
 	 * @return the bean
 	 */
 	@Bean
 	public CreateServiceInstanceAppBindingWorkflow credhubPersistingCreateServiceInstanceAppBindingWorkflow(
-		CredHubOperations credHubOperations) {
+		ReactiveCredHubOperations credHubOperations) {
 		return new CredHubPersistingCreateServiceInstanceAppBindingWorkflow(credHubOperations, appName);
 	}
 
 	/**
 	 * Provide a {@link DeleteServiceInstanceBindingWorkflow} bean
 	 *
-	 * @param credHubOperations the CredHubOperations bean
+	 * @param credHubOperations the ReactiveCredHubOperations bean
 	 * @return the bean
 	 */
 	@Bean
 	public DeleteServiceInstanceBindingWorkflow credhubPersistingDeleteServiceInstanceAppBindingWorkflow(
-		CredHubOperations credHubOperations) {
+		ReactiveCredHubOperations credHubOperations) {
 		return new CredHubPersistingDeleteServiceInstanceBindingWorkflow(credHubOperations, appName);
 	}
 
 	/**
 	 * Provide a {@link CredHubCredentialsGenerator} bean
 	 *
-	 * @param credHubOperations the CredHubOperations bean
+	 * @param credHubOperations the ReactiveCredHubOperations bean
 	 * @return the bean
 	 */
 	@Bean
-	public CredHubCredentialsGenerator credHubCredentialsGenerator(CredHubOperations credHubOperations) {
+	public CredHubCredentialsGenerator credHubCredentialsGenerator(ReactiveCredHubOperations credHubOperations) {
 		return new CredHubCredentialsGenerator(credHubOperations);
 	}
 

--- a/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/CredHubAutoConfigurationTest.java
+++ b/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/CredHubAutoConfigurationTest.java
@@ -28,9 +28,9 @@ import org.springframework.cloud.appbroker.extensions.credentials.SimpleCredenti
 import org.springframework.cloud.appbroker.workflow.binding.CredHubPersistingCreateServiceInstanceAppBindingWorkflow;
 import org.springframework.cloud.appbroker.workflow.binding.CredHubPersistingDeleteServiceInstanceBindingWorkflow;
 import org.springframework.context.annotation.Bean;
-import org.springframework.credhub.core.CredHubOperations;
-import org.springframework.credhub.core.CredHubTemplate;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.credhub.core.ReactiveCredHubOperations;
+import org.springframework.credhub.core.ReactiveCredHubTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -52,7 +52,7 @@ class CredHubAutoConfigurationTest {
 	@Test
 	void servicesAreNotCreatedWithoutCredHubOnClasspath() {
 		contextRunner
-			.withClassLoader(new FilteredClassLoader(CredHubOperations.class))
+			.withClassLoader(new FilteredClassLoader(ReactiveCredHubOperations.class))
 			.run((context) -> {
 				assertThat(context)
 					.hasSingleBean(CredentialGenerator.class)
@@ -84,8 +84,8 @@ class CredHubAutoConfigurationTest {
 	public static class CredHubConfiguration {
 
 		@Bean
-		public CredHubOperations credHubOperations() {
-			return new CredHubTemplate(new RestTemplate());
+		public ReactiveCredHubOperations credHubOperations() {
+			return new ReactiveCredHubTemplate(WebClient.create());
 		}
 
 	}

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/CredentialGenerator.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/CredentialGenerator.java
@@ -22,13 +22,11 @@ import reactor.util.function.Tuple2;
 public interface CredentialGenerator {
 
 	Mono<Tuple2<String, String>> generateUser(String applicationId, String serviceInstanceId, String descriptor,
-		int length, boolean includeUppercaseAlpha,
-		boolean includeLowercaseAlpha, boolean includeNumeric,
+		int length, boolean includeUppercaseAlpha, boolean includeLowercaseAlpha, boolean includeNumeric,
 		boolean includeSpecial);
 
 	Mono<String> generateString(String applicationId, String serviceInstanceId, String descriptor,
-		int length, boolean includeUppercaseAlpha,
-		boolean includeLowercaseAlpha, boolean includeNumeric,
+		int length, boolean includeUppercaseAlpha, boolean includeLowercaseAlpha, boolean includeNumeric,
 		boolean includeSpecial);
 
 	default Mono<Void> deleteUser(String applicationId, String serviceInstanceId, String descriptor) {

--- a/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/fixtures/WiremockServerFixture.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/fixtures/WiremockServerFixture.java
@@ -28,11 +28,14 @@ import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.test.context.TestComponent;
+import org.springframework.cloud.appbroker.autoconfigure.CloudFoundryAppDeployerAutoConfiguration;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@AutoConfigureBefore(CloudFoundryAppDeployerAutoConfiguration.class)
 @TestComponent
 public class WiremockServerFixture {
 

--- a/spring-cloud-app-broker-security-credhub/build.gradle
+++ b/spring-cloud-app-broker-security-credhub/build.gradle
@@ -25,12 +25,14 @@ dependencyManagement {
 dependencies {
 	compile project(":spring-cloud-app-broker-core")
 	compile("org.springframework.credhub:spring-credhub-starter:${springCredhubVersion}")
+	compile("org.springframework.cloud:spring-cloud-open-service-broker-core:${openServiceBrokerVersion}")
 
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
 	testImplementation("org.springframework.boot:spring-boot-starter-test") {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 	}
+	testImplementation("org.springframework.boot:spring-boot-starter-webflux")
 	testImplementation("io.projectreactor:reactor-test")
 	testImplementation("io.projectreactor.tools:blockhound-junit-platform:${blockHoundVersion}")
 }

--- a/spring-cloud-app-broker-security-credhub/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/CredHubCredentialsGenerator.java
+++ b/spring-cloud-app-broker-security-credhub/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/CredHubCredentialsGenerator.java
@@ -20,7 +20,7 @@ import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
-import org.springframework.credhub.core.CredHubOperations;
+import org.springframework.credhub.core.ReactiveCredHubOperations;
 import org.springframework.credhub.support.CredentialDetails;
 import org.springframework.credhub.support.SimpleCredentialName;
 import org.springframework.credhub.support.password.PasswordCredential;
@@ -31,23 +31,22 @@ import org.springframework.credhub.support.user.UserParametersRequest;
 
 public class CredHubCredentialsGenerator implements CredentialGenerator {
 
-	private final CredHubOperations credHubOperations;
+	private final ReactiveCredHubOperations credHubOperations;
 
-	public CredHubCredentialsGenerator(CredHubOperations credHubOperations) {
+	public CredHubCredentialsGenerator(ReactiveCredHubOperations credHubOperations) {
 		this.credHubOperations = credHubOperations;
 	}
 
 	@Override
 	public Mono<Tuple2<String, String>> generateUser(String applicationId, String serviceInstanceId, String descriptor,
-		int length, boolean includeUppercaseAlpha, boolean includeLowercaseAlpha,
-		boolean includeNumeric, boolean includeSpecial) {
-		return Mono.fromCallable(() -> this.credHubOperations.credentials().generate(UserParametersRequest.builder()
+		int length, boolean includeUppercaseAlpha, boolean includeLowercaseAlpha, boolean includeNumeric,
+		boolean includeSpecial) {
+		return credHubOperations.credentials().generate(UserParametersRequest.builder()
 			.name(new SimpleCredentialName(applicationId, serviceInstanceId, descriptor))
 			.parameters(passwordParameters(length, includeUppercaseAlpha, includeLowercaseAlpha, includeNumeric,
 				includeSpecial))
-			.build()))
+			.build(), UserCredential.class)
 			.map(CredentialDetails::getValue)
-			.cast(UserCredential.class)
 			.map(userCredential -> Tuples.of(userCredential.getUsername(), userCredential.getPassword()));
 	}
 
@@ -55,39 +54,31 @@ public class CredHubCredentialsGenerator implements CredentialGenerator {
 	public Mono<String> generateString(String applicationId, String serviceInstanceId, String descriptor, int length,
 		boolean includeUppercaseAlpha, boolean includeLowercaseAlpha, boolean includeNumeric,
 		boolean includeSpecial) {
-		return Mono.fromCallable(() -> credHubOperations.credentials().generate(PasswordParametersRequest.builder()
-			.name(new SimpleCredentialName(applicationId, serviceInstanceId, descriptor))
-			.parameters(passwordParameters(length, includeUppercaseAlpha, includeLowercaseAlpha, includeNumeric,
-				includeSpecial))
-			.build()))
+		return credHubOperations.credentials()
+			.generate(PasswordParametersRequest.builder()
+				.name(new SimpleCredentialName(applicationId, serviceInstanceId, descriptor))
+				.parameters(passwordParameters(length, includeUppercaseAlpha, includeLowercaseAlpha, includeNumeric,
+					includeSpecial))
+				.build(), PasswordCredential.class)
 			.map(CredentialDetails::getValue)
-			.cast(PasswordCredential.class)
 			.map(PasswordCredential::getPassword);
 	}
 
 	@Override
 	public Mono<Void> deleteUser(String applicationId, String serviceInstanceId, String descriptor) {
-		return Mono.fromCallable(() -> {
-			this.credHubOperations.credentials()
-				.deleteByName(new SimpleCredentialName(applicationId, serviceInstanceId, descriptor));
-			return null;
-		});
+		return credHubOperations.credentials()
+			.deleteByName(new SimpleCredentialName(applicationId, serviceInstanceId, descriptor));
 	}
 
 	@Override
 	public Mono<Void> deleteString(String applicationId, String serviceInstanceId, String descriptor) {
-		return Mono.fromCallable(() -> {
-			this.credHubOperations.credentials()
-				.deleteByName(new SimpleCredentialName(applicationId, serviceInstanceId, descriptor));
-			return null;
-		});
+		return credHubOperations.credentials()
+			.deleteByName(new SimpleCredentialName(applicationId, serviceInstanceId, descriptor));
 	}
 
 	private PasswordParameters passwordParameters(int length, boolean includeUppercaseAlpha,
-		boolean includeLowercaseAlpha,
-		boolean includeNumeric, boolean includeSpecial) {
-		return PasswordParameters
-			.builder()
+		boolean includeLowercaseAlpha, boolean includeNumeric, boolean includeSpecial) {
+		return PasswordParameters.builder()
 			.length(length)
 			.excludeUpper(!includeUppercaseAlpha)
 			.excludeLower(!includeLowercaseAlpha)


### PR DESCRIPTION
- Replace the use of the imperative Spring CredHub APIs in favor of the
reactive alternatives.
- Build against the latest Spring CredHub snapshots
- Increase heap memory for component tests