### PR TITLE
Support custom BrokeredServices to be injected by custom configuration

### DIFF
--- a/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfiguration.java
+++ b/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfiguration.java
@@ -139,6 +139,7 @@ public class AppBrokerAutoConfiguration {
 	 */
 	@Bean
 	@ConfigurationProperties(PROPERTY_PREFIX + ".services")
+	@ConditionalOnMissingBean
 	public BrokeredServices brokeredServices() {
 		return BrokeredServices.builder().build();
 	}

--- a/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfigurationTest.java
+++ b/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfigurationTest.java
@@ -27,6 +27,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cloud.appbroker.deployer.BackingAppDeploymentService;
 import org.springframework.cloud.appbroker.deployer.BackingApplications;
 import org.springframework.cloud.appbroker.deployer.BackingServicesProvisionService;
+import org.springframework.cloud.appbroker.deployer.BrokeredService;
 import org.springframework.cloud.appbroker.deployer.BrokeredServices;
 import org.springframework.cloud.appbroker.deployer.DeployerClient;
 import org.springframework.cloud.appbroker.extensions.credentials.CredentialGenerator;
@@ -171,6 +172,20 @@ class AppBrokerAutoConfigurationTest {
 	}
 
 	@Test
+	void brokeredServicesIsNotCreatedIfProvided() {
+		configuredContext()
+			.withUserConfiguration(CustomBrokeredServicesConfiguration.class)
+			.run(context -> {
+				assertBeansCreated(context);
+
+				assertThat(context)
+					.hasSingleBean(BrokeredServices.class)
+					.getBean(BrokeredServices.class)
+					.isEqualTo(new CustomBrokeredServicesConfiguration().brokeredServices());
+			});
+	}
+
+	@Test
 	void serviceInstanceBindingStateRepositoryIsNotCreatedIfProvided() {
 		configuredContext()
 			.withUserConfiguration(CustomStateRepositoriesConfiguration.class)
@@ -295,6 +310,20 @@ class AppBrokerAutoConfigurationTest {
 			return new TestServiceInstanceService();
 		}
 
+	}
+
+	@Configuration
+	public static class CustomBrokeredServicesConfiguration {
+
+		@Bean
+		public BrokeredServices brokeredServices() {
+			return BrokeredServices.builder().service(
+				BrokeredService.builder()
+					.serviceName("single-service")
+					.planName("service1-plan1")
+					.build())
+				.build();
+		}
 	}
 
 	@Configuration


### PR DESCRIPTION
This PR enables application built ontop of SCAB to provide custom BrokeredServices bean.

This supports a use-case described in #285 , in particular a dynamically generated catalog, see more details into https://github.com/orange-cloudfoundry/osb-cmdb-spike#dynamic-catalog and https://github.com/orange-cloudfoundry/osb-cmdb-spike/pull/1