### PR TITLE
TargetSpec equals and hashcode

### DIFF
--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/TargetSpec.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/TargetSpec.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.appbroker.deployer;
 
+import java.util.Objects;
+
 public class TargetSpec {
 
 	private String name;
@@ -40,6 +42,23 @@ public class TargetSpec {
 		return new TargetSpecBuilder();
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		TargetSpec that = (TargetSpec) o;
+		return Objects.equals(name, that.name);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(name);
+	}
+
 	public static final class TargetSpecBuilder {
 
 		private String name;
@@ -51,11 +70,9 @@ public class TargetSpec {
 			this.name = name;
 			return this;
 		}
-
 		public TargetSpec build() {
 			return new TargetSpec(name);
 		}
 
 	}
-
 }


### PR DESCRIPTION
This PR provides an implementation for TargetSpec equals() and hashCode() as provided by intellij java7 template.

This supports the #285 and the dynamic catalog, to be able to compare BrokeredService which invoke TargetSpec.equals

https://github.com/spring-cloud/spring-cloud-app-broker/blob/b0c71e52de361ef097c3a6e27e9d63b291a6ed4c/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/BrokeredService.java#L106 