### PR TITLE
Opt-in for dynamically generated catalog and brokered services (WIP)

### DIFF
--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/DynamicServiceAutoConfigurationAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/DynamicServiceAutoConfigurationAcceptanceTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.acceptance;
+
+import java.util.Collection;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jdk.nashorn.internal.ir.annotations.Ignore;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.appbroker.acceptance.fixtures.cf.CloudFoundryClientConfiguration;
+import org.springframework.cloud.appbroker.acceptance.fixtures.cf.CloudFoundryProperties;
+import org.springframework.cloud.appbroker.autoconfigure.DynamicCatalogConstants;
+import org.springframework.cloud.appbroker.autoconfigure.DynamicCatalogServiceAutoConfiguration;
+import org.springframework.cloud.appbroker.deployer.BrokeredServices;
+import org.springframework.cloud.servicebroker.model.catalog.Catalog;
+import org.springframework.cloud.servicebroker.model.catalog.Plan;
+import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// Expects the Cf client properties to be injected as system properties
+// and the corresponding Cf marketplace to be non empty
+class DynamicServiceAutoConfigurationAcceptanceTest {
+	private final Logger logger = LoggerFactory.getLogger(getClass());
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(
+			CloudFoundryProperties.class,
+			CloudFoundryClientConfiguration.class,
+			DynamicCatalogServiceAutoConfiguration.class
+		))
+		.withPropertyValues(DynamicCatalogConstants.OPT_IN_PROPERTY+"=true");
+
+	@Test
+	void contextLoadWithCatalogCreatedWhenPropertiesProvided() {
+		configuredContext()
+			.run(context -> {
+				BrokeredServices brokeredServices = context.getBean(BrokeredServices.class);
+				assertThat(brokeredServices).isNotEmpty();
+				Catalog catalog = context.getBean(Catalog.class);
+				assertThat(catalog.getServiceDefinitions()).isNotEmpty();
+
+				List<ServiceDefinition> serviceDefinitions = catalog.getServiceDefinitions();
+				assertThat(serviceDefinitions).isNotEmpty();
+				serviceDefinitions.stream()
+					.map(ServiceDefinition::getPlans)
+					.flatMap(Collection::stream)
+					.forEach(this::assertPlanIsValid);
+
+				assertThat(context).hasSingleBean(Catalog.class);
+				assertThat(context).hasSingleBean(BrokeredServices.class);
+			});
+	}
+
+	private void assertPlanIsValid(Plan plan)  {
+		assertThat(plan.getId()).isNotNull(); // Plan id is required
+		assertPlanSerializesWithoutInvalidSchemas(plan);
+	}
+
+	private void assertPlanSerializesWithoutInvalidSchemas(Plan plan) {
+		try {
+			ObjectMapper mapper = new ObjectMapper();
+			String serializedSchemas = mapper.writeValueAsString(plan.getSchemas());
+			logger.info("serializedSchemas {}", serializedSchemas);
+			assertThat(serializedSchemas).doesNotContain(":null");
+			// Preventing CC message "Schema service_instance.create.parameters is not valid. Schema must have $schema key but was not present"
+			// in schemas like:
+			//               "create": { "parameters": {} }
+			assertThat(serializedSchemas).doesNotContain("\"parameters\": {}");
+		}
+		catch (JsonProcessingException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+
+	@Test
+	@Ignore
+		//Not yet implemented
+	void catalogFetchingFailuresThrowsException() {
+		//TODO: fail if the flux contains error events (was the case when Jackson was not configured to ignore
+	}
+
+
+	private ApplicationContextRunner configuredContext() {
+		return this.contextRunner;
+	}
+
+
+
+}

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/fixtures/cf/CloudFoundryService.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/fixtures/cf/CloudFoundryService.java
@@ -218,7 +218,8 @@ public class CloudFoundryService {
 				.name(serviceInstanceName)
 				.build())
 			.doOnSuccess(item -> LOGGER.info("Got service instance " + serviceInstanceName))
-			.doOnError(error -> LOGGER.error("Error getting service instance " + serviceInstanceName + ": " + error));
+			.doOnError(error -> LOGGER.error("Error getting service instance " + serviceInstanceName + ": " + error,
+				error));
 	}
 
 	public Mono<List<ApplicationSummary>> getApplications() {

--- a/spring-cloud-app-broker-autoconfigure/build.gradle
+++ b/spring-cloud-app-broker-autoconfigure/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	compile("org.cloudfoundry:cloudfoundry-client-reactor:${cfJavaClientVersion}")
 	compile("org.cloudfoundry:cloudfoundry-operations:${cfJavaClientVersion}")
 	compile("org.springframework.credhub:spring-credhub-starter:${springCredhubVersion}")
+	compile("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.9")
 
 	annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 	annotationProcessor("org.springframework.boot:spring-boot-autoconfigure-processor")

--- a/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/BaseMapper.java
+++ b/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/BaseMapper.java
@@ -1,0 +1,42 @@
+package org.springframework.cloud.appbroker.autoconfigure;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BaseMapper {
+	private final Logger logger = LoggerFactory.getLogger(getClass());
+
+	protected Map<String, Object> toServiceMetaData(String extraJson) {
+		if (extraJson ==null) {
+			return new HashMap<>();
+		}
+		logger.debug("extraJson {}", extraJson);
+		//enforce check keys can't be mapped to other java primitives: Boolean, Integers
+		//potentially customizing jackson deserialization
+		// See https://www.baeldung.com/jackson-map
+		TypeReference<HashMap<String, Object>> typeRef = new TypeReference<HashMap<String, Object>>() {};
+		Map<String, Object> metadata = fromJson(extraJson, typeRef);
+		logger.debug("metadata {}", metadata);
+		return metadata;
+	}
+
+	protected <T> T fromJson(String json, TypeReference<HashMap<String, Object>> contentType) {
+		try {
+			ObjectMapper mapper = new ObjectMapper();
+			mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+			return mapper.readerFor(contentType).readValue(json);
+		}
+		catch (IOException e) {
+			logger.error("Unable to parse json, caught: " + e, e);
+			throw new IllegalStateException(e);
+		}
+	}
+
+}

--- a/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/BrokeredServicesCatalogMapper.java
+++ b/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/BrokeredServicesCatalogMapper.java
@@ -1,0 +1,77 @@
+package org.springframework.cloud.appbroker.autoconfigure;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.cloud.appbroker.deployer.BackingService;
+import org.springframework.cloud.appbroker.deployer.BackingServices;
+import org.springframework.cloud.appbroker.deployer.BrokeredService;
+import org.springframework.cloud.appbroker.deployer.BrokeredServices;
+import org.springframework.cloud.appbroker.deployer.TargetSpec;
+import org.springframework.cloud.appbroker.extensions.targets.SpacePerServiceInstance;
+import org.springframework.cloud.servicebroker.model.catalog.Catalog;
+import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
+
+public class BrokeredServicesCatalogMapper {
+
+	private final ServiceDefinitionMapperProperties serviceDefinitionMapperProperties;
+
+	public BrokeredServicesCatalogMapper(ServiceDefinitionMapperProperties serviceDefinitionMapperProperties) {
+		this.serviceDefinitionMapperProperties = serviceDefinitionMapperProperties;
+	}
+
+	public BrokeredServices toBrokeredServices(Catalog catalog) {
+		List<BrokeredServices> services = catalog.getServiceDefinitions().stream()
+			.map(this::toBrokeredServices)
+			.collect(Collectors.toList());
+
+		BrokeredServices.BrokeredServicesBuilder builder = BrokeredServices.builder();
+		services.stream()
+			.sequential()
+			.forEach(builder::services);
+		return builder.build();
+	}
+
+	private BrokeredServices toBrokeredServices(ServiceDefinition serviceDefinition) {
+		BrokeredServices.BrokeredServicesBuilder builder = BrokeredServices.builder();
+		serviceDefinition.getPlans().stream().sequential()
+			.forEach(p -> builder.service(toBrokeredService(serviceDefinition.getName(), p.getName())));
+		return builder.build();
+	}
+
+	private BrokeredService toBrokeredService(String serviceName, String planName) {
+		String originalBackingServiceName = removePreprocessingIfAny(serviceName);
+		return
+			BrokeredService.builder()
+				.serviceName(serviceName)
+				.planName(planName)
+				.services(BackingServices.builder()
+					.backingService(toBackingService(originalBackingServiceName, planName))
+					.build())
+				.target(TargetSpec.builder()
+					.name(SpacePerServiceInstance.class.getSimpleName())
+					.build())
+				.build();
+	}
+
+	private String removePreprocessingIfAny(String serviceName) {
+		String suffix = this.serviceDefinitionMapperProperties.getSuffix();
+		if (suffix == null) {
+			return serviceName;
+		}
+		//noinspection UnnecessaryLocalVariable
+		String serviceNameWithoutSuffix = serviceName.substring(0, serviceName.length() - suffix.length());
+		return serviceNameWithoutSuffix;
+	}
+
+	private BackingService toBackingService(String serviceName, String planName) {
+		return BackingService.builder()
+			.name(serviceName)
+			.plan(planName)
+			.serviceInstanceName(serviceName)
+			.build();
+	}
+
+
+
+}

--- a/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/DynamicCatalogConstants.java
+++ b/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/DynamicCatalogConstants.java
@@ -1,0 +1,12 @@
+package org.springframework.cloud.appbroker.autoconfigure;
+
+/**
+ * Note: this is not yet a full Properties class with fields since DynamicCatalogService does not yet require config.
+ * Instead, granular Properties classes are defined for services and plan mapper.
+ */
+public class DynamicCatalogConstants {
+
+	public static final String PROPERTY_PREFIX = "osbcmdb.dynamic-catalog";
+	public static final String OPT_IN_PROPERTY = PROPERTY_PREFIX + ".enabled";
+
+}

--- a/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/DynamicCatalogService.java
+++ b/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/DynamicCatalogService.java
@@ -1,0 +1,11 @@
+package org.springframework.cloud.appbroker.autoconfigure;
+
+import java.util.List;
+
+import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
+
+public interface DynamicCatalogService {
+
+	List<ServiceDefinition> fetchServiceDefinitions();
+
+}

--- a/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/DynamicCatalogServiceAutoConfiguration.java
+++ b/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/DynamicCatalogServiceAutoConfiguration.java
@@ -1,0 +1,134 @@
+package org.springframework.cloud.appbroker.autoconfigure;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.cloudfoundry.client.CloudFoundryClient;
+import org.cloudfoundry.operations.CloudFoundryOperations;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.appbroker.deployer.BrokeredServices;
+import org.springframework.cloud.appbroker.deployer.cloudfoundry.CloudFoundryDeploymentProperties;
+import org.springframework.cloud.appbroker.deployer.cloudfoundry.CloudFoundryTargetProperties;
+import org.springframework.cloud.servicebroker.model.catalog.Catalog;
+import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.Assert;
+
+@Configuration
+@AutoConfigureBefore(AppBrokerAutoConfiguration.class)
+@ConditionalOnProperty(value= DynamicCatalogConstants.OPT_IN_PROPERTY)
+@EnableConfigurationProperties
+public class DynamicCatalogServiceAutoConfiguration {
+
+	private final Logger logger = LoggerFactory.getLogger(getClass());
+	private BrokeredServices brokeredServices;
+	private Catalog catalog;
+
+	@Bean
+	@ConfigurationProperties(prefix = PlanMapperProperties.PROPERTY_PREFIX, ignoreUnknownFields = false)
+	public PlanMapperProperties planMapperProperties() {
+		return new PlanMapperProperties();
+	}
+
+	@Bean
+	@ConfigurationProperties(prefix = ServiceDefinitionMapperProperties.PROPERTY_PREFIX, ignoreUnknownFields = false)
+	public ServiceDefinitionMapperProperties serviceDefinitionMapperProperties() {
+		return new ServiceDefinitionMapperProperties();
+	}
+
+	@Bean
+	public ServiceDefinitionMapper serviceDefinitionMapper(
+		PlanMapper planMapper,
+		ServiceDefinitionMapperProperties serviceDefinitionMapperProperties) {
+		return new ServiceDefinitionMapper(planMapper, serviceDefinitionMapperProperties);
+	}
+
+	@Bean
+	public PlanMapper planMapper(PlanMapperProperties planMapperProperties) {
+		return new PlanMapper(planMapperProperties);
+	}
+
+	@Bean
+	public DynamicCatalogService dynamicCatalogService(
+		CloudFoundryDeploymentProperties defaultDeploymentProperties,
+		CloudFoundryOperations operations,
+		CloudFoundryClient cloudFoundryClient,
+		CloudFoundryTargetProperties targetProperties,
+		ServiceDefinitionMapper serviceDefinitionMapper) {
+
+		logger.info("Will be fetching catalog from org {} and space {}",
+			targetProperties.getDefaultOrg(), targetProperties.getDefaultSpace());
+
+		return new DynamicCatalogServiceImpl(
+			defaultDeploymentProperties,
+			operations,
+			cloudFoundryClient,
+			targetProperties,
+			serviceDefinitionMapper);
+	}
+
+	@Bean
+	public BrokeredServicesCatalogMapper brokeredServicesCatalogMapper(
+		ServiceDefinitionMapperProperties serviceDefinitionMapperProperties) {
+		return new BrokeredServicesCatalogMapper(serviceDefinitionMapperProperties);
+	}
+
+	@Bean
+	public Catalog catalog(DynamicCatalogService dynamicCatalogService,
+		BrokeredServicesCatalogMapper brokeredServicesCatalogMapper) {
+		brokeredServices = brokeredServices(dynamicCatalogService,
+			brokeredServicesCatalogMapper);
+		return catalog;
+	}
+
+	@Bean
+	public BrokeredServices brokeredServices(DynamicCatalogService dynamicCatalogService,
+		BrokeredServicesCatalogMapper brokeredServicesCatalogMapper) {
+		initializeCatalog(dynamicCatalogService, brokeredServicesCatalogMapper);
+		return brokeredServices;
+	}
+
+	private void initializeCatalog(DynamicCatalogService dynamicCatalogService,
+		BrokeredServicesCatalogMapper brokeredServicesCatalogMapper) {
+		if (catalog == null || brokeredServices == null) {
+			List<ServiceDefinition> serviceDefinitions = dynamicCatalogService.fetchServiceDefinitions();
+			Assert.notEmpty(serviceDefinitions, "Unexpected empty marketplace dynamically fetched");
+
+			this.catalog = Catalog.builder().serviceDefinitions(serviceDefinitions).build();
+			Assert.notEmpty(catalog.getServiceDefinitions(),
+				"Unexpected empty mapped catalog, check configured filters");
+
+			brokeredServices = brokeredServicesCatalogMapper.toBrokeredServices(this.catalog);
+			Assert.notEmpty(catalog.getServiceDefinitions(),
+				"Unexpected empty list of brokered services, check configured filters");
+
+			logger.info("Mapped catalog is: {}", catalog);
+			logger.info("Mapped brokered services are: {}", brokeredServices);
+
+			dumpCatalogToDisk();
+		}
+	}
+
+	private void dumpCatalogToDisk() {
+		try {
+			ServiceConfigurationYamlDumper serviceConfigurationYamlDumper = new ServiceConfigurationYamlDumper();
+			serviceConfigurationYamlDumper.dumpToYamlFile(catalog, brokeredServices);
+			if (logger.isDebugEnabled()) {
+				String yamlDebug = serviceConfigurationYamlDumper.dumpToYamlString(catalog, brokeredServices);
+				logger.debug("Mapped catalog yml is {}", yamlDebug);
+			}
+		}
+		catch (IOException e) {
+			//Don't fail application start
+			logger.error("Unable to dump dynamic catalog to disk, caught: " + e, e);
+		}
+	}
+
+}

--- a/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/DynamicCatalogServiceImpl.java
+++ b/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/DynamicCatalogServiceImpl.java
@@ -1,0 +1,115 @@
+package org.springframework.cloud.appbroker.autoconfigure;
+
+import java.util.List;
+
+import org.cloudfoundry.client.CloudFoundryClient;
+import org.cloudfoundry.client.v2.serviceplans.ListServicePlansRequest;
+import org.cloudfoundry.client.v2.serviceplans.ServicePlanResource;
+import org.cloudfoundry.client.v2.services.ServiceEntity;
+import org.cloudfoundry.client.v2.services.ServiceResource;
+import org.cloudfoundry.client.v2.spaces.ListSpaceServicesRequest;
+import org.cloudfoundry.operations.CloudFoundryOperations;
+import org.cloudfoundry.operations.DefaultCloudFoundryOperations;
+import org.cloudfoundry.operations.util.OperationsLogging;
+import org.cloudfoundry.util.PaginationUtils;
+import org.cloudfoundry.util.ResourceUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.util.function.Tuples;
+
+import org.springframework.cloud.appbroker.deployer.cloudfoundry.CloudFoundryDeploymentProperties;
+import org.springframework.cloud.appbroker.deployer.cloudfoundry.CloudFoundryTargetProperties;
+import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
+
+import static org.cloudfoundry.util.tuple.TupleUtils.function;
+
+public class DynamicCatalogServiceImpl implements DynamicCatalogService {
+
+	private static final Logger logger = LoggerFactory.getLogger(DynamicCatalogServiceImpl.class);
+
+	protected CloudFoundryOperations operations;
+	private Mono<CloudFoundryClient> cloudFoundryClient;
+	private CloudFoundryTargetProperties targetProperties;
+	private ServiceDefinitionMapper serviceDefinitionMapper;
+
+	public DynamicCatalogServiceImpl(
+		CloudFoundryDeploymentProperties defaultDeploymentProperties,
+		CloudFoundryOperations operations,
+		CloudFoundryClient cloudFoundryClient,
+		CloudFoundryTargetProperties targetProperties,
+		ServiceDefinitionMapper serviceDefinitionMapper) {
+
+		this.serviceDefinitionMapper = serviceDefinitionMapper;
+		this.operations = operations;
+		this.cloudFoundryClient = Mono.just(cloudFoundryClient);
+		this.targetProperties = targetProperties;
+	}
+
+	@Override
+	public List<ServiceDefinition> fetchServiceDefinitions() {
+		final Mono<String> finalSpaceId = getOperationsForOrgAndSpace().cast(DefaultCloudFoundryOperations.class)
+			.flatMap(DefaultCloudFoundryOperations::getSpaceId);
+		//Inspired from cf-java-client: org.cloudfoundry.operations.services.DefaultServices.listServiceOfferings
+		return Mono.zip(this.cloudFoundryClient, finalSpaceId)
+			.flatMapMany(function((cloudFoundryClient, spaceId) -> requestListServices(cloudFoundryClient, spaceId)
+				.map(resource -> Tuples.of(cloudFoundryClient, resource))
+			))
+			.flatMap(function((cloudFoundryClient, resource) -> Mono.zip(
+				Mono.just(resource),
+				getServicePlans(cloudFoundryClient, ResourceUtils.getId(resource))
+			)))
+			.filter(t-> filterServiceEntity(t.getT1().getEntity()))
+			.map(function(
+				(resource1, servicePlans) -> serviceDefinitionMapper.toServiceDefinition(resource1, servicePlans)))
+			.transform(OperationsLogging.log("List Service Definitions"))
+			.checkpoint()
+			.collectList().block();
+	}
+
+	private boolean filterServiceEntity(ServiceEntity entity) {
+		return serviceDefinitionMapper.shouldMapServiceEntity(entity);
+	}
+
+
+	private static Mono<List<ServicePlanResource>> getServicePlans(CloudFoundryClient cloudFoundryClient, String serviceId) {
+		return requestListServicePlans(cloudFoundryClient, serviceId)
+			.collectList();
+	}
+
+	private static Flux<ServicePlanResource> requestListServicePlans(CloudFoundryClient cloudFoundryClient, String serviceId) {
+		return PaginationUtils
+			.requestClientV2Resources(page -> cloudFoundryClient.servicePlans()
+				.list(ListServicePlansRequest.builder()
+					.page(page)
+					.serviceId(serviceId)
+					.build()));
+	}
+
+	private static Flux<ServiceResource> requestListServices(CloudFoundryClient cloudFoundryClient, String spaceId) {
+		return PaginationUtils
+			.requestClientV2Resources(page -> cloudFoundryClient.spaces()
+				.listServices(ListSpaceServicesRequest.builder()
+					.page(page)
+					.spaceId(spaceId)
+					.build()));
+	}
+
+
+	private Mono<CloudFoundryOperations> getOperationsForOrgAndSpace() {
+		return Mono.just(this.operations)
+			.cast(DefaultCloudFoundryOperations.class)
+			.map(cfOperations -> DefaultCloudFoundryOperations.builder()
+				.from(cfOperations)
+				.organization(targetProperties.getDefaultOrg())
+				.space(targetProperties.getDefaultSpace())
+				.build())
+			.cast(CloudFoundryOperations.class)
+			.doOnRequest(item -> logger
+				.info("targetted operations to space {} and org {}", targetProperties.getDefaultOrg(),
+					targetProperties.getDefaultSpace()));
+	}
+
+
+}

--- a/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/PlanMapper.java
+++ b/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/PlanMapper.java
@@ -1,0 +1,166 @@
+package org.springframework.cloud.appbroker.autoconfigure;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.cloudfoundry.client.v2.Metadata;
+import org.cloudfoundry.client.v2.serviceplans.Parameters;
+import org.cloudfoundry.client.v2.serviceplans.Schema;
+import org.cloudfoundry.client.v2.serviceplans.ServicePlanEntity;
+import org.cloudfoundry.client.v2.serviceplans.ServicePlanResource;
+import org.cloudfoundry.util.ResourceUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.servicebroker.model.catalog.MethodSchema;
+import org.springframework.cloud.servicebroker.model.catalog.Plan;
+import org.springframework.cloud.servicebroker.model.catalog.Schemas;
+import org.springframework.cloud.servicebroker.model.catalog.ServiceBindingSchema;
+import org.springframework.cloud.servicebroker.model.catalog.ServiceInstanceSchema;
+
+public class PlanMapper extends BaseMapper {
+
+	private static final Logger logger = LoggerFactory.getLogger(PlanMapper.class);
+
+	private final PlanMapperProperties properties;
+
+	public PlanMapper(PlanMapperProperties properties) {
+		this.properties = properties;
+	}
+
+	public List<Plan> toPlans(List<ServicePlanResource> servicePlans) {
+		return servicePlans.stream()
+			.map(this::toPlan)
+			.collect(Collectors.toList());
+	}
+
+	private Plan toPlan(ServicePlanResource resource) {
+		Plan.PlanBuilder planBuilder = Plan.builder();
+
+		Metadata metadata = resource.getMetadata();
+		if (metadata != null) { //mostly during lazy unit tests
+			planBuilder = planBuilder
+				.id(metadata.getId());
+		}
+		ServicePlanEntity entity = ResourceUtils.getEntity(resource);
+		planBuilder = planBuilder
+			.name(entity.getName())
+			.free(entity.getFree())
+			.bindable(entity.getBindable())
+			.description(entity.getDescription())
+			.metadata(toServiceMetaData(entity.getExtra()));
+		planBuilder = toSchemas(planBuilder, entity.getSchemas());
+
+		Plan plan = planBuilder.build();
+
+		logger.debug("plan entity {}", plan);
+		return plan;
+	}
+
+	private Plan.PlanBuilder toSchemas(Plan.PlanBuilder planBuilder, org.cloudfoundry.client.v2.serviceplans.Schemas entitySchemas) {
+		if (entitySchemas == null) {
+			return planBuilder;
+		}
+		Schemas.SchemasBuilder builder = toBindingBuilder(Schemas.builder(), entitySchemas.getServiceBinding());
+		builder = toInstanceBuilder(builder, entitySchemas.getServiceInstance());
+		Schemas schemas = builder.build();
+		planBuilder= planBuilder.schemas(schemas);
+		return planBuilder;
+	}
+
+	private Schemas.SchemasBuilder toInstanceBuilder(Schemas.SchemasBuilder builder, org.cloudfoundry.client.v2.serviceplans.ServiceInstanceSchema entitySchemas) {
+		if (entitySchemas == null) {
+			return builder;
+		}
+		ServiceInstanceSchema.ServiceInstanceSchemaBuilder serviceInstanceSchemaBuilder =
+			ServiceInstanceSchema.builder();
+		serviceInstanceSchemaBuilder = toCreateServiceInstanceSchemaBuilder(serviceInstanceSchemaBuilder, entitySchemas.getCreate());
+		serviceInstanceSchemaBuilder = toUpdateServiceInstanceSchemaBuilder(serviceInstanceSchemaBuilder, entitySchemas.getUpdate());
+		builder = builder.serviceInstanceSchema(serviceInstanceSchemaBuilder.build());
+		return builder;
+	}
+
+	private Schemas.SchemasBuilder toBindingBuilder(Schemas.SchemasBuilder builder, org.cloudfoundry.client.v2.serviceplans.ServiceBindingSchema entitySchemas) {
+		if (entitySchemas == null) {
+			return builder;
+		}
+		ServiceBindingSchema.ServiceBindingSchemaBuilder serviceBindingSchemaBuilder = ServiceBindingSchema.builder();
+		serviceBindingSchemaBuilder = toCreateServiceBindingSchemaBuilder(serviceBindingSchemaBuilder, entitySchemas.getCreate());
+
+		builder = builder.serviceBindingSchema(serviceBindingSchemaBuilder.build());
+		return builder;
+	}
+
+	private ServiceBindingSchema.ServiceBindingSchemaBuilder toCreateServiceBindingSchemaBuilder(
+		ServiceBindingSchema.ServiceBindingSchemaBuilder builder, Schema entitySchema) {
+		if (entitySchema == null) {
+			return builder;
+		}
+		MethodSchema.MethodSchemaBuilder methodSchemaBuilder = toParameters(entitySchema.getParameters());
+		if (methodSchemaBuilder == null) {
+			return builder;
+		}
+		return builder
+			.createMethodSchema(methodSchemaBuilder
+				.build());
+	}
+
+	private ServiceInstanceSchema.ServiceInstanceSchemaBuilder toUpdateServiceInstanceSchemaBuilder(
+		ServiceInstanceSchema.ServiceInstanceSchemaBuilder builder, Schema entitySchema) {
+		if (entitySchema == null) {
+			return builder;
+		}
+		MethodSchema.MethodSchemaBuilder methodSchemaBuilder = toParameters(entitySchema.getParameters());
+		if (methodSchemaBuilder == null) {
+			return builder;
+		}
+		return builder
+			.updateMethodSchema(methodSchemaBuilder
+			.build());
+	}
+
+	private ServiceInstanceSchema.ServiceInstanceSchemaBuilder toCreateServiceInstanceSchemaBuilder(
+		ServiceInstanceSchema.ServiceInstanceSchemaBuilder builder, Schema entitySchema) {
+		if (entitySchema == null) {
+			return builder;
+		}
+		MethodSchema.MethodSchemaBuilder methodSchemaBuilder = toParameters(entitySchema.getParameters());
+		if (methodSchemaBuilder == null) {
+			return builder;
+		}
+		return builder
+			.createMethodSchema(methodSchemaBuilder
+				.build());
+	}
+
+	/**
+	 * maps a schema. Care to taken to avoid setting empty schema that CF rejects
+	 * @return a Builder if a schema should be set, or null otherwise
+	 */
+	private MethodSchema.MethodSchemaBuilder toParameters(Parameters parameters) {
+		if (parameters == null) {
+			return null;
+		}
+		Map<String, Object> properties = parameters.getProperties();
+		String jsonSchema = parameters.getJsonSchema();
+		String type = parameters.getType();
+		if (properties == null &&
+			jsonSchema == null &&
+			type == null) {
+			return null;
+		}
+		MethodSchema.MethodSchemaBuilder builder = MethodSchema.builder();
+		if (properties != null) {
+			builder = builder.parameters("properties", properties);
+		}
+		if (jsonSchema != null) {
+			builder = builder.parameters("$schema", jsonSchema);
+		}
+		if (type!= null) {
+			builder = builder.parameters("type", type);
+		}
+		return builder;
+	}
+
+}

--- a/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/PlanMapperProperties.java
+++ b/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/PlanMapperProperties.java
@@ -1,0 +1,19 @@
+package org.springframework.cloud.appbroker.autoconfigure;
+
+public class PlanMapperProperties {
+
+	public static final String PROPERTY_PREFIX = DynamicCatalogConstants.PROPERTY_PREFIX + ".plans";
+
+//For future use
+//	/**
+//	 * Define a suffix to service plan names
+//	 */
+//	public static final String SUFFIX_PROPERTY_KEY="suffix";
+//
+//	private String planNameSuffix="";
+//
+//	public String getPlanNameSuffix() { return planNameSuffix; }
+//
+//	public void setPlanNameSuffix(String planNameSuffix) { this.planNameSuffix = planNameSuffix; }
+//
+}

--- a/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/ServiceConfigurationYamlDumper.java
+++ b/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/ServiceConfigurationYamlDumper.java
@@ -1,0 +1,103 @@
+package org.springframework.cloud.appbroker.autoconfigure;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.appbroker.deployer.BrokeredServices;
+import org.springframework.cloud.servicebroker.model.catalog.Catalog;
+
+public class ServiceConfigurationYamlDumper {
+
+	private final Logger logger = LoggerFactory.getLogger(getClass());
+	public static final String CATALOG_DUMP_PATH = "/tmp/osb-cmdb-dynamicCatalog.yml";
+
+	private static String TO_VALID_DRAFT_04 =
+		"              parameters[$schema]: \"http://json-schema.org/draft-04/schema#\"\n" +
+		"              parameters:\n";
+	private static String FROM_DRAFT04 =
+		"              parameters:\n" +
+		"                $schema: \"http://json-schema.org/draft-04/schema#\"\n";
+
+	private static String TO_VALID_DRAFT_06 =
+		"              parameters[$schema]: \"http://json-schema.org/draft-06/schema#\"\n" +
+		"              parameters:\n";
+	private static String FROM_DRAFT06 =
+		"              parameters:\n" +
+		"                $schema: \"http://json-schema.org/draft-06/schema#\"\n";
+
+	public String dumpToYamlString(Catalog catalog, BrokeredServices brokeredServices) throws JsonProcessingException {
+		ObjectWriter objectWriter = getYamlWriter();
+		ApplicationYaml yamlToDump = new ApplicationYaml(catalog, brokeredServices);
+		String yamlString = objectWriter.writeValueAsString(yamlToDump);
+		return applyScOsbYamlWorkaround(yamlString);
+	}
+
+	/**
+	 * Spring cloud osb has a specific syntax to support catalog config schemas
+	 * See https://github.com/spring-cloud/spring-cloud-open-service-broker/blob/fe7cea3df1222d6acacdaec670852bf484d8aa60/spring-cloud-open-service-broker-autoconfigure/src/test/resources/catalog-full.yml#L76
+	 */
+	private String applyScOsbYamlWorkaround(String yamlString) {
+		yamlString = yamlString.replace(FROM_DRAFT04, TO_VALID_DRAFT_04);
+		yamlString = yamlString.replace(FROM_DRAFT06, TO_VALID_DRAFT_06);
+		return yamlString;
+	}
+
+	public void dumpToYamlFile(Catalog catalog, BrokeredServices brokeredServices) throws IOException {
+		String yamlString = dumpToYamlString(catalog, brokeredServices);
+		try (Writer writer = buildFileWriter()) {
+			writer.write(yamlString);
+		}
+		logger.info("Dumped dynamic catalog to {}", CATALOG_DUMP_PATH);
+	}
+
+	private Writer buildFileWriter() throws IOException {
+		return new FileWriter(CATALOG_DUMP_PATH, false);
+	}
+
+	private ObjectWriter getYamlWriter() {
+		YAMLFactory yamlFactory = new YAMLFactory();
+		//Disable yaml document header to make it easier to copy/paste. See https://www.baeldung.com/jackson-yaml
+		yamlFactory.disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
+		ObjectMapper objectMapper = new ObjectMapper(yamlFactory);
+		//Try to make the output somewhat deterministic as to make diffs among version easier
+		//still lacking sorting the array
+		// https://www.stubbornjava.com/posts/creating-a-somewhat-deterministic-jackson-objectmapper
+		objectMapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+		objectMapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+	return objectMapper.writer().withRootName("spring.cloud");
+	}
+
+	//	@JsonRootName("spring.cloud") //Seems to be ignored
+	public static class ApplicationYaml {
+		@JsonProperty("appbroker.services")
+		private BrokeredServices brokeredServices;
+		@JsonProperty("openservicebroker.catalog")
+		private Catalog catalog;
+
+		public ApplicationYaml(Catalog catalog,
+			BrokeredServices brokeredServices) {
+			this.brokeredServices = brokeredServices;
+			this.catalog = catalog;
+		}
+
+		public BrokeredServices getBrokeredServices() { return brokeredServices; }
+		public void setBrokeredServices(BrokeredServices brokeredServices) { this.brokeredServices = brokeredServices; }
+		public Catalog getCatalog() { return catalog; }
+		public void setCatalog(Catalog catalog) { this.catalog = catalog; }
+
+	}
+
+
+}

--- a/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/ServiceDefinitionMapper.java
+++ b/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/ServiceDefinitionMapper.java
@@ -1,0 +1,83 @@
+package org.springframework.cloud.appbroker.autoconfigure;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.cloudfoundry.client.v2.serviceplans.ServicePlanResource;
+import org.cloudfoundry.client.v2.services.ServiceEntity;
+import org.cloudfoundry.client.v2.services.ServiceResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
+
+public class ServiceDefinitionMapper extends BaseMapper {
+
+	private final Logger logger = LoggerFactory.getLogger(getClass());
+
+	private final PlanMapper planMapper;
+	private ServiceDefinitionMapperProperties serviceDefinitionMapperProperties;
+
+	public ServiceDefinitionMapper(PlanMapper planMapper,
+		ServiceDefinitionMapperProperties serviceDefinitionMapperProperties) {
+		this.planMapper = planMapper;
+		this.serviceDefinitionMapperProperties = serviceDefinitionMapperProperties;
+	}
+
+	/**
+	 * Decides whether the specified entity should be mapped
+	 * @param entity
+	 * @return true if the entity should be preserved and mapped, false if the entity should be skipped
+	 */
+	public boolean shouldMapServiceEntity(ServiceEntity entity) {
+		String excludeBrokerNamesRegexp = serviceDefinitionMapperProperties.getExcludeBrokerNamesRegexp();
+		if (excludeBrokerNamesRegexp == null) {
+			return true;
+		}
+		String serviceBrokerName = entity.getServiceBrokerName();
+		if (serviceBrokerName == null) {
+			logger.error("Unexpected missing broker name in service {}, filtering it out", entity);
+			return false;
+		}
+		boolean shouldMapEntity = !Pattern.matches(excludeBrokerNamesRegexp, serviceBrokerName);
+		if (!shouldMapEntity) {
+			logger.info("Filtering out service {} as it is excluded by configured rexgexp {}", entity,
+				excludeBrokerNamesRegexp);
+		}
+		return shouldMapEntity;
+	}
+
+	public ServiceDefinition toServiceDefinition(ServiceResource resource,
+		List<ServicePlanResource> servicePlans) {
+
+		ServiceEntity entity = resource.getEntity();
+		return ServiceDefinition.builder()
+			.id(resource.getMetadata().getId())
+			.name(entity.getLabel() + serviceDefinitionMapperProperties.getSuffix())
+			.description(entity.getDescription())
+			.tags(safeList(entity.getTags()))
+			.bindable(safeBoolean(entity.getBindable()))
+			.planUpdateable(safeBoolean(entity.getPlanUpdateable()))
+			.bindingsRetrievable(safeBoolean(entity.getBindingsRetrievable()))
+			.instancesRetrievable(safeBoolean(entity.getInstancesRetrievable()))
+			.plans(planMapper.toPlans(safeList(servicePlans)))
+			.metadata(toServiceMetaData(entity.getExtra()))
+			.build();
+	}
+
+	private <R> List<R> safeList(List<R> list) {
+		if (list == null) {
+			return Collections.emptyList();
+		}
+		return list;
+	}
+
+	private Boolean safeBoolean(Boolean field) {
+		if (field == null) {
+			return Boolean.FALSE;
+		}
+		return field;
+	}
+
+}

--- a/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/ServiceDefinitionMapperProperties.java
+++ b/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/ServiceDefinitionMapperProperties.java
@@ -1,0 +1,32 @@
+package org.springframework.cloud.appbroker.autoconfigure;
+
+public class ServiceDefinitionMapperProperties {
+
+	public static final String PROPERTY_PREFIX = DynamicCatalogConstants.PROPERTY_PREFIX + ".catalog.services";
+
+	/**
+	 * Adds a suffix to service names
+	 */
+	public static final String SUFFIX_PROPERTY_KEY=".suffix";
+
+	/**
+	 * Excludes some broker whose name matches the regexp.
+	 * Default is missing property, i.e. null (i.e no exclusion)
+	 */
+	public static final String EXCLUDE_BROKER_PROPERTY_KEY=".excludeBrokerNamesRegexp";
+
+	private String suffix ="";
+
+	private String excludeBrokerNamesRegexp = null;
+
+	public String getSuffix() { return suffix; }
+
+	public void setSuffix(String suffix) { this.suffix = suffix; }
+
+	public String getExcludeBrokerNamesRegexp() { return excludeBrokerNamesRegexp; }
+
+	public void setExcludeBrokerNamesRegexp(String excludeBrokerNamesRegexp) {
+		this.excludeBrokerNamesRegexp = excludeBrokerNamesRegexp;
+	}
+
+}

--- a/spring-cloud-app-broker-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-app-broker-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.springframework.cloud.appbroker.autoconfigure.CloudFoundryAppDeployerAutoConfiguration,\
 org.springframework.cloud.appbroker.autoconfigure.CredHubAutoConfiguration,\
-org.springframework.cloud.appbroker.autoconfigure.AppBrokerAutoConfiguration
+org.springframework.cloud.appbroker.autoconfigure.AppBrokerAutoConfiguration,\
+org.springframework.cloud.appbroker.autoconfigure.DynamicCatalogServiceAutoConfiguration

--- a/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/BrokeredServicesCatalogMapperTest.java
+++ b/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/BrokeredServicesCatalogMapperTest.java
@@ -1,0 +1,67 @@
+package org.springframework.cloud.appbroker.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.appbroker.deployer.BackingServices;
+import org.springframework.cloud.appbroker.deployer.BrokeredService;
+import org.springframework.cloud.appbroker.deployer.BrokeredServices;
+import org.springframework.cloud.appbroker.deployer.TargetSpec;
+import org.springframework.cloud.servicebroker.model.catalog.Catalog;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BrokeredServicesCatalogMapperTest extends SampleServicesBuilderBaseTest {
+	private final Logger logger = LoggerFactory.getLogger(getClass());
+
+	@Test
+	void mapsCatalogToBrokeredServices() {
+		Catalog catalog = Catalog.builder()
+			.serviceDefinitions(asList(
+				buildServiceDefinition("mysql", "10mb", "20mb"),
+				buildServiceDefinition("noop", "default")))
+			.build();
+
+		BrokeredServices brokeredServices = new BrokeredServicesCatalogMapper(new ServiceDefinitionMapperProperties()).toBrokeredServices(catalog);
+		logger.info("brokered services: {}", brokeredServices);
+		BrokeredServices expectedBrokeredServices = BrokeredServices.builder()
+			.service(buildBrokeredService("mysql", "10mb"))
+			.service(buildBrokeredService("mysql", "20mb"))
+			.service(buildBrokeredService("noop", "default"))
+			.build();
+		assertThat(brokeredServices).isEqualTo(expectedBrokeredServices);
+	}
+
+	@Test
+	void mapsSuffixedCatalogToUnsuffixedBrokeredServices() {
+		//given
+		Catalog catalog = Catalog.builder()
+			.serviceDefinitions(asList(
+				buildServiceDefinition("mysql-suffixed", "10mb")))
+			.build();
+		ServiceDefinitionMapperProperties serviceDefinitionMapperProperties = new ServiceDefinitionMapperProperties();
+		serviceDefinitionMapperProperties.setSuffix("-suffixed");
+
+		//when
+		BrokeredServices brokeredServices = new BrokeredServicesCatalogMapper(serviceDefinitionMapperProperties).toBrokeredServices(catalog);
+
+		//then
+		logger.info("brokered services: {}", brokeredServices);
+		BrokeredServices expectedBrokeredServices = BrokeredServices.builder()
+			.service(BrokeredService.builder()
+				.serviceName("mysql-suffixed")
+				.planName("10mb")
+				.services(BackingServices.builder()
+					.backingService(buildBackingService("mysql", "10mb"))
+					.build())
+				.target(TargetSpec.builder()
+					.name("SpacePerServiceInstance")
+					.build())
+				.build())
+			.build();
+		assertThat(brokeredServices).isEqualTo(expectedBrokeredServices);
+	}
+
+}

--- a/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/DynamicCatalogServiceAutoConfigurationTest.java
+++ b/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/DynamicCatalogServiceAutoConfigurationTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.autoconfigure;
+
+import java.util.List;
+
+import org.cloudfoundry.client.CloudFoundryClient;
+import org.cloudfoundry.operations.CloudFoundryOperations;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.appbroker.deployer.BrokeredServices;
+import org.springframework.cloud.appbroker.deployer.cloudfoundry.CloudFoundryDeploymentProperties;
+import org.springframework.cloud.appbroker.deployer.cloudfoundry.CloudFoundryTargetProperties;
+import org.springframework.cloud.servicebroker.model.catalog.Catalog;
+import org.springframework.cloud.servicebroker.model.catalog.Plan;
+import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DynamicCatalogServiceAutoConfigurationTest {
+
+	private static final Logger logger = LoggerFactory.getLogger(DynamicCatalogServiceAutoConfigurationTest.class);
+
+	@Test
+	void contextFailsWhenOptInButMissingDependencies() {
+		ApplicationContextRunner applicationContextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(DynamicCatalogServiceAutoConfiguration.class))
+			.withSystemProperties(DynamicCatalogConstants.OPT_IN_PROPERTY + "=true");
+		applicationContextRunner.run(context -> {
+			assertThat(context).hasFailed();
+		});
+	}
+
+	@Test
+	void dynamicServiceDontLoadWhenNoPropertiesSet() {
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(
+				DynamicCatalogServiceAutoConfiguration.class,
+				MockedDynamicCatalogDependenciesAutoConfiguration.class))
+			.run(context -> {
+				assertThat(context).doesNotHaveBean(DynamicCatalogServiceAutoConfiguration.class);
+			});
+	}
+
+	@Test
+	void dynamicServiceLoadWhenOptInProperty() {
+		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(
+				SingleServiceDefinitionAnswerAutoConfig.class,
+				DynamicCatalogServiceAutoConfiguration.class
+			))
+//			.withPropertyValues(DynamicCatalogProperties.OPT_IN_PROPERTY + "=true") //Not sure why this seems ignored
+			.withSystemProperties(DynamicCatalogConstants.OPT_IN_PROPERTY + "=true");
+		contextRunner.run(context -> {
+			Catalog catalog = context.getBean(Catalog.class);
+			assertThat(catalog.getServiceDefinitions()).isNotEmpty();
+			BrokeredServices brokeredServices = context.getBean(BrokeredServices.class);
+			assertThat(brokeredServices).isNotEmpty();
+
+			assertThat(context).hasSingleBean(Catalog.class);
+			assertThat(context).hasSingleBean(BrokeredServices.class);
+		});
+	}
+
+	@Test
+	void serviceDefinitionMapperPropertiesAreProperlyLoaded() {
+		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(
+				SingleServiceDefinitionAnswerAutoConfig.class,
+				DynamicCatalogServiceAutoConfiguration.class
+			))
+//			.withPropertyValues(DynamicCatalogProperties.OPT_IN_PROPERTY + "=true") //Not sure why this seems ignored
+			.withSystemProperties(DynamicCatalogConstants.OPT_IN_PROPERTY + "=true",
+				ServiceDefinitionMapperProperties.PROPERTY_PREFIX
+					+ServiceDefinitionMapperProperties.SUFFIX_PROPERTY_KEY+ "=suffix")
+		;
+		contextRunner.run(context -> {
+			assertThat(context).hasSingleBean(ServiceDefinitionMapperProperties.class);
+			ServiceDefinitionMapperProperties serviceDefinitionMapperProperties
+				= context.getBean(ServiceDefinitionMapperProperties.class);
+			assertThat(serviceDefinitionMapperProperties.getSuffix()).isEqualTo("suffix");
+		});
+	}
+
+	@Test
+	void catalogFetchingFailuresTriggersContextFailure() {
+		ApplicationContextRunner applicationContextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(
+				DynamicCatalogServiceAutoConfiguration.class,
+				ThrowingExceptionServiceDefinitionAnswerAutoConfig.class))
+			.withSystemProperties(DynamicCatalogConstants.OPT_IN_PROPERTY + "=true");
+		applicationContextRunner.run(context -> {
+			assertThat(context).hasFailed();
+		});
+	}
+
+	@Test
+	void emptyCatalogFetchedTriggersContextFailure() {
+		ApplicationContextRunner applicationContextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(
+				DynamicCatalogServiceAutoConfiguration.class,
+				EmptyServiceDefinitionAnswerAutoConfig.class))
+			.withSystemProperties(DynamicCatalogConstants.OPT_IN_PROPERTY + "=true");
+		applicationContextRunner.run(context -> {
+			assertThat(context).hasFailed();
+		});
+	}
+
+
+
+	@Configuration
+	static class MockedDynamicCatalogDependenciesAutoConfiguration {
+		@Bean
+		CloudFoundryDeploymentProperties defaultDeploymentProperties() {
+			return mock(CloudFoundryDeploymentProperties.class);
+		}
+		@Bean
+		CloudFoundryOperations operations() {
+			return mock(CloudFoundryOperations.class);
+		}
+		@Bean
+		CloudFoundryClient cloudFoundryClient() {
+			return mock(CloudFoundryClient.class);
+		}
+		@Bean
+		CloudFoundryTargetProperties targetProperties () {
+			return mock(CloudFoundryTargetProperties.class);
+		}
+	}
+
+	@Configuration
+	static abstract class MockedDynamicServiceConfig {
+		@Bean
+		DynamicCatalogService dynamicCatalogService() {
+			DynamicCatalogService dynamicCatalogService = mock(DynamicCatalogService.class);
+			when(dynamicCatalogService.fetchServiceDefinitions()).thenReturn(this.serviceDefinitionsAnswer());
+			return dynamicCatalogService;
+		}
+
+		protected abstract List<ServiceDefinition> serviceDefinitionsAnswer();
+
+	}
+
+	@Configuration
+	static class SingleServiceDefinitionAnswerAutoConfig extends MockedDynamicServiceConfig {
+		protected List<ServiceDefinition> serviceDefinitionsAnswer() {
+			String serviceName = "serviceName";
+			String planName = "planName";
+			return asList(ServiceDefinition
+				.builder()
+				.id(serviceName + "-id")
+				.name(serviceName)
+				.plans(Plan.builder()
+					.id(planName + "-id")
+					.name(planName)
+					.build())
+				.build()
+			);
+		}
+	}
+
+	@Configuration
+	static class EmptyServiceDefinitionAnswerAutoConfig extends MockedDynamicServiceConfig {
+		protected List<ServiceDefinition> serviceDefinitionsAnswer() {
+			return emptyList();
+		}
+	}
+
+	@Configuration
+	static class ThrowingExceptionServiceDefinitionAnswerAutoConfig  {
+		@Bean
+		DynamicCatalogService dynamicCatalogService() {
+			DynamicCatalogService dynamicCatalogService = mock(DynamicCatalogService.class);
+			when(dynamicCatalogService.fetchServiceDefinitions()).thenThrow(new RuntimeException("Injected exception " +
+				"while fetching catalog "));
+			return dynamicCatalogService;
+		}
+	}
+
+
+}

--- a/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/PlanMapperTest.java
+++ b/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/PlanMapperTest.java
@@ -1,0 +1,201 @@
+package org.springframework.cloud.appbroker.autoconfigure;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.cloudfoundry.client.v2.Metadata;
+import org.cloudfoundry.client.v2.serviceplans.Schema;
+import org.cloudfoundry.client.v2.serviceplans.Schemas;
+import org.cloudfoundry.client.v2.serviceplans.ServiceBindingSchema;
+import org.cloudfoundry.client.v2.serviceplans.ServiceInstanceSchema;
+import org.cloudfoundry.client.v2.serviceplans.ServicePlanEntity;
+import org.cloudfoundry.client.v2.serviceplans.ServicePlanResource;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.servicebroker.model.catalog.Plan;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlanMapperTest {
+
+	private static final Logger logger = LoggerFactory.getLogger(PlanMapperTest.class);
+
+	@Test
+	void mapsPlanResourcesIntoPlan() throws JsonProcessingException {
+		List<ServicePlanResource> servicePlans = asList(
+		ServicePlanResource.builder()
+			.entity(ServicePlanEntity.builder()
+				.name("plan1")
+				.active(true)
+				.bindable(true)
+				.description("description")
+				.extra("{\"displayName\":\"Big Bunny\"}")
+				.free(false)
+				.build())
+			.metadata(Metadata.builder()
+				.id("plan-id")
+				.build())
+			.build(),
+		ServicePlanResource.builder()
+			.entity(ServicePlanEntity.builder()
+				.name("plan2")
+				.build())
+			.build());
+
+
+		PlanMapper planMapper = new PlanMapper(new PlanMapperProperties());
+
+		List<Plan> plans = planMapper.toPlans(servicePlans);
+		assertThat(plans).hasSize(2);
+		Plan plan1 = plans.get(0);
+		assertThat(plan1.getName()).isEqualTo("plan1");
+		assertThat(plan1.getDescription()).isEqualTo("description");
+		assertThat(plan1.isBindable()).isTrue();
+		assertThat(plan1.isFree()).isFalse();
+		assertThat(plan1.getId()).isEqualTo("plan-id");
+		assertPlanSerializesWithoutPollutingWithNulls(plan1);
+		Plan plan2 = plans.get(1);
+		assertThat(plan2.getName()).isEqualTo("plan2");
+		assertPlanSerializesWithoutPollutingWithNulls(plan2);
+	}
+
+	@Test
+	void mapsPlanExtraToMetadata() {
+		List<ServicePlanResource> servicePlans = Collections.singletonList(
+			ServicePlanResource.builder()
+				.entity(ServicePlanEntity.builder()
+					.name("plan1")
+					.active(true)
+					.bindable(true)
+					.description("description")
+					.extra("{\"displayName\":\"Big Bunny\"}")
+					.free(false)
+					.build())
+				.build());
+
+
+		PlanMapper planMapper = new PlanMapper(new PlanMapperProperties());
+
+		List<Plan> plans = planMapper.toPlans(servicePlans);
+		assertThat(plans).hasSize(1);
+		Plan plan = plans.get(0);
+		assertThat(plan.getMetadata()).hasSize(1);
+		assertThat(plan.getMetadata().get("displayName")).isEqualTo("Big Bunny");
+	}
+
+	@Test
+	void doesNotAddNullInDeserializedEmptySchemas() {
+		//given a Schemas object deserialized from a CF API response (which differs from what the builder produces)
+	    String serializedSchemas = 
+			"{\n" +
+			" \"service_instance\": {\n" +
+			"  \"create\": {\n" +
+			"   \"parameters\": {}\n" +
+			"  },\n" +
+			"  \"update\": {\n" +
+			"   \"parameters\": {}\n" +
+			"  }\n" +
+			" },\n" +
+			" \"service_binding\": {\n" +
+			"  \"create\": {\n" +
+			"   \"parameters\": {}\n" +
+			"  }\n" +
+			" }\n" +
+			"}\n";
+		Schemas schemas = fromJson(serializedSchemas, Schemas.class);
+		List<ServicePlanResource> servicePlans = Collections.singletonList(
+			ServicePlanResource.builder()
+				.entity(ServicePlanEntity.builder()
+					.name("plan1")
+					.extra("{}")
+					.schemas(schemas)
+					.build())
+				.build());
+
+		PlanMapper planMapper = new PlanMapper(new PlanMapperProperties());
+
+		//when
+		List<Plan> plans = planMapper.toPlans(servicePlans);
+
+		//then
+		assertPlanSerializesWithoutPollutingWithNulls(plans.get(0));
+	}
+
+	private <T> T fromJson(String json, Class<T> contentType) {
+		try {
+			ObjectMapper mapper = new ObjectMapper();
+			mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+			return mapper.readerFor(contentType).readValue(json);
+		}
+		catch (IOException e) {
+			logger.error("Unable to parse json, caught: " + e, e);
+			throw new IllegalStateException(e);
+		}
+	}
+
+
+	@Test
+	void doesNotAddNullsInEmptySchemasInMappedPlans() {
+		//given
+		List<ServicePlanResource> servicePlans = Collections.singletonList(
+			ServicePlanResource.builder()
+				.entity(ServicePlanEntity.builder()
+					.name("plan1")
+					.extra("{}")
+					.schemas(Schemas.builder()
+						.serviceBinding(ServiceBindingSchema.builder()
+							.create(Schema.builder().build())
+							.build())
+						.serviceInstance(ServiceInstanceSchema.builder()
+							.create(Schema.builder().build())
+							.update(Schema.builder().build())
+							.build())
+						.build())
+					.build())
+				.build());
+
+
+		PlanMapper planMapper = new PlanMapper(new PlanMapperProperties());
+
+		//when
+		List<Plan> plans = planMapper.toPlans(servicePlans);
+
+		//then
+		assertPlanSerializesWithoutPollutingWithNulls(plans.get(0));
+	}
+
+	@Test
+	void PlanSerializesWithoutPollutingEmptySchemaObjects() {
+		Plan plan = Plan.builder()
+			.name("10mb")
+			.build();
+		assertPlanSerializesWithoutPollutingWithNulls(plan);
+	}
+
+	private void assertPlanSerializesWithoutPollutingWithNulls(Plan plan)  {
+		if (plan == null) {
+			return;
+		}
+		try {
+			ObjectMapper mapper = new ObjectMapper();
+			String serializedSchemas = mapper.writeValueAsString(plan.getSchemas());
+			logger.info("serializedSchemas {}", serializedSchemas);
+			assertThat(serializedSchemas).doesNotContain(":null");
+			// Preventing CC message "Schema service_instance.create.parameters is not valid. Schema must have $schema key but was not present"
+			// in schemas like:
+			//               "create": { "parameters": {} }
+			assertThat(serializedSchemas).doesNotContain("\"parameters\": {}");
+		}
+		catch (JsonProcessingException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+}

--- a/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/SampleServicesBuilderBaseTest.java
+++ b/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/SampleServicesBuilderBaseTest.java
@@ -1,0 +1,56 @@
+package org.springframework.cloud.appbroker.autoconfigure;
+
+import java.util.stream.Stream;
+
+import org.springframework.cloud.appbroker.deployer.BackingService;
+import org.springframework.cloud.appbroker.deployer.BackingServices;
+import org.springframework.cloud.appbroker.deployer.BrokeredService;
+import org.springframework.cloud.appbroker.deployer.TargetSpec;
+import org.springframework.cloud.servicebroker.model.catalog.Plan;
+import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
+
+public class SampleServicesBuilderBaseTest {
+
+	protected BrokeredService buildBrokeredService(String serviceName, String planName) {
+		return
+			BrokeredService.builder()
+				.serviceName(serviceName)
+				.planName(planName)
+				.services(BackingServices.builder()
+					.backingService(buildBackingService(serviceName, planName))
+					.build())
+				.target(TargetSpec.builder()
+					.name("SpacePerServiceInstance")
+					.build())
+				.build();
+	}
+
+	protected ServiceDefinition buildServiceDefinition(String serviceName, String... planNames) {
+		return ServiceDefinition.builder()
+			.id(serviceName + "-id")
+			.name(serviceName)
+			.description("description " +  serviceName)
+			.plans(
+				buildPlan(planNames))
+			.build();
+	}
+
+	protected BackingService buildBackingService(String serviceName, String planName) {
+		return BackingService.builder()
+			.name(serviceName)
+			.plan(planName)
+			.serviceInstanceName(serviceName)
+			.build();
+	}
+
+	protected Plan[] buildPlan(String[] planNames) {
+		return Stream.of(planNames)
+			.map(planName-> Plan.builder()
+				.id(planName + "-id")
+				.name(planName)
+				.description("description " +  planName)
+				.build())
+			.toArray(Plan[]::new);
+	}
+
+}

--- a/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/ServiceConfigurationYamlDumperTest.java
+++ b/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/ServiceConfigurationYamlDumperTest.java
@@ -1,0 +1,219 @@
+package org.springframework.cloud.appbroker.autoconfigure;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.cloud.appbroker.deployer.BrokeredServices;
+import org.springframework.cloud.servicebroker.model.catalog.Catalog;
+import org.springframework.cloud.servicebroker.model.catalog.MethodSchema;
+import org.springframework.cloud.servicebroker.model.catalog.Plan;
+import org.springframework.cloud.servicebroker.model.catalog.Schemas;
+import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
+import org.springframework.cloud.servicebroker.model.catalog.ServiceInstanceSchema;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ServiceConfigurationYamlDumperTest extends SampleServicesBuilderBaseTest {
+
+	@Test
+	void dumpsBrokeredServicesToYamlStringAndDisk() throws IOException {
+		//given
+		Catalog catalog = Catalog.builder()
+			.serviceDefinitions(asList(
+				buildServiceDefinition("mysql", "10mb", "20mb"),
+				buildServiceDefinition("noop", "default")))
+			.build();
+
+		BrokeredServices brokeredServices = BrokeredServices.builder()
+			.service(buildBrokeredService("mysql", "10mb"))
+			.service(buildBrokeredService("mysql", "20mb"))
+			.service(buildBrokeredService("noop", "default"))
+			.build();
+
+		//when
+		ServiceConfigurationYamlDumper serviceConfigurationYamlDumper = new ServiceConfigurationYamlDumper();
+		String applicationYml = serviceConfigurationYamlDumper.dumpToYamlString(catalog, brokeredServices);
+
+		//then
+		String expectedYaml
+			= "spring.cloud:\n" +
+			"  appbroker.services:\n" +
+			"  - apps: null\n" +
+			"    planName: \"10mb\"\n" +
+			"    serviceName: \"mysql\"\n" +
+			"    services:\n" +
+			"    - name: \"mysql\"\n" +
+			"      parameters: {}\n" +
+			"      parametersTransformers: []\n" +
+			"      plan: \"10mb\"\n" +
+			"      properties: {}\n" +
+			"      rebindOnUpdate: false\n" +
+			"      serviceInstanceName: \"mysql\"\n" +
+			"    target:\n" +
+			"      name: \"SpacePerServiceInstance\"\n" +
+			"  - apps: null\n" +
+			"    planName: \"20mb\"\n" +
+			"    serviceName: \"mysql\"\n" +
+			"    services:\n" +
+			"    - name: \"mysql\"\n" +
+			"      parameters: {}\n" +
+			"      parametersTransformers: []\n" +
+			"      plan: \"20mb\"\n" +
+			"      properties: {}\n" +
+			"      rebindOnUpdate: false\n" +
+			"      serviceInstanceName: \"mysql\"\n" +
+			"    target:\n" +
+			"      name: \"SpacePerServiceInstance\"\n" +
+			"  - apps: null\n" +
+			"    planName: \"default\"\n" +
+			"    serviceName: \"noop\"\n" +
+			"    services:\n" +
+			"    - name: \"noop\"\n" +
+			"      parameters: {}\n" +
+			"      parametersTransformers: []\n" +
+			"      plan: \"default\"\n" +
+			"      properties: {}\n" +
+			"      rebindOnUpdate: false\n" +
+			"      serviceInstanceName: \"noop\"\n" +
+			"    target:\n" +
+			"      name: \"SpacePerServiceInstance\"\n" +
+			"  openservicebroker.catalog:\n" +
+			"    services:\n" +
+			"    - bindable: false\n" +
+			"      description: \"description mysql\"\n" +
+			"      id: \"mysql-id\"\n" +
+			"      name: \"mysql\"\n" +
+			"      plans:\n" +
+			"      - description: \"description 10mb\"\n" +
+			"        free: true\n" +
+			"        id: \"10mb-id\"\n" +
+			"        name: \"10mb\"\n" +
+			"      - description: \"description 20mb\"\n" +
+			"        free: true\n" +
+			"        id: \"20mb-id\"\n" +
+			"        name: \"20mb\"\n" +
+			"    - bindable: false\n" +
+			"      description: \"description noop\"\n" +
+			"      id: \"noop-id\"\n" +
+			"      name: \"noop\"\n" +
+			"      plans:\n" +
+			"      - description: \"description default\"\n" +
+			"        free: true\n" +
+			"        id: \"default-id\"\n" +
+			"        name: \"default\"\n";
+		assertThat(applicationYml).isEqualTo(expectedYaml);
+
+		//and when
+		serviceConfigurationYamlDumper.dumpToYamlFile(catalog, brokeredServices);
+
+		//then
+		String readYamlFromFile = readFileFromDisk();
+		assertThat(readYamlFromFile).isEqualTo(expectedYaml);
+	}
+
+	/**
+	 * Spring cloud osb has a specific syntax to support catalog config schemas
+	 * See https://github.com/spring-cloud/spring-cloud-open-service-broker/blob/fe7cea3df1222d6acacdaec670852bf484d8aa60/spring-cloud-open-service-broker-autoconfigure/src/test/resources/catalog-full.yml#L76
+	 */
+	@Test
+	void dumpsBrokeredServicesWithValidSchemaToYamlStringAndDisk() throws IOException {
+		//given
+		Catalog catalog = Catalog.builder()
+			.serviceDefinitions(asList(
+				ServiceDefinition.builder()
+					.id("noop" + "-id")
+					.name("noop")
+					.description("description " + "noop")
+					.plans(
+						Stream.of(new String[] {"default"})
+							.map(planName -> Plan.builder()
+								.id(planName + "-id")
+								.name(planName)
+								.description("description " + planName)
+								.schemas(Schemas.builder()
+									.serviceInstanceSchema(ServiceInstanceSchema.builder()
+										.createMethodSchema(MethodSchema.builder()
+											.parameters("$schema", "http://json-schema.org/draft-04/schema#")
+											.parameters("type", "object")
+											.build())
+										.updateMethodSchema(MethodSchema.builder()
+											.parameters("$schema", "http://json-schema.org/draft-06/schema#")
+											.parameters("type", "string")
+											.build())
+										.build())
+									.build())
+								.build())
+							.toArray(Plan[]::new))
+					.build()))
+			.build();
+
+		BrokeredServices brokeredServices = BrokeredServices.builder()
+			.service(buildBrokeredService("noop", "default"))
+			.build();
+
+		//when
+		ServiceConfigurationYamlDumper serviceConfigurationYamlDumper = new ServiceConfigurationYamlDumper();
+		String applicationYml = serviceConfigurationYamlDumper.dumpToYamlString(catalog, brokeredServices);
+
+		//then
+		String expectedYaml
+			= "spring.cloud:\n" +
+			"  appbroker.services:\n" +
+			"  - apps: null\n" +
+			"    planName: \"default\"\n" +
+			"    serviceName: \"noop\"\n" +
+			"    services:\n" +
+			"    - name: \"noop\"\n" +
+			"      parameters: {}\n" +
+			"      parametersTransformers: []\n" +
+			"      plan: \"default\"\n" +
+			"      properties: {}\n" +
+			"      rebindOnUpdate: false\n" +
+			"      serviceInstanceName: \"noop\"\n" +
+			"    target:\n" +
+			"      name: \"SpacePerServiceInstance\"\n" +
+			"  openservicebroker.catalog:\n" +
+			"    services:\n" +
+			"    - bindable: false\n" +
+			"      description: \"description noop\"\n" +
+			"      id: \"noop-id\"\n" +
+			"      name: \"noop\"\n" +
+			"      plans:\n" +
+			"      - description: \"description default\"\n" +
+			"        free: true\n" +
+			"        id: \"default-id\"\n" +
+			"        name: \"default\"\n" +
+			"        schemas:\n" +
+			"          service_instance:\n" +
+			"            create:\n" +
+			"              parameters[$schema]: \"http://json-schema.org/draft-04/schema#\"\n" +
+			"              parameters:\n" +
+			"                type: \"object\"\n" +
+			"            update:\n" +
+			"              parameters[$schema]: \"http://json-schema.org/draft-06/schema#\"\n" +
+			"              parameters:\n" +
+			"                type: \"string\"\n";
+		assertThat(applicationYml).isEqualTo(expectedYaml);
+
+		//and when
+		serviceConfigurationYamlDumper.dumpToYamlFile(catalog, brokeredServices);
+
+		//then
+		String readYamlFromFile = readFileFromDisk();
+		assertThat(readYamlFromFile).doesNotContain("$schema:");
+		assertThat(readYamlFromFile).isEqualTo(expectedYaml);
+	}
+
+	private String readFileFromDisk() throws IOException {
+		return new String(
+				Files.readAllBytes(
+					FileSystems.getDefault().getPath(
+						ServiceConfigurationYamlDumper.CATALOG_DUMP_PATH)));
+	}
+
+}

--- a/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/ServiceDefinitionMapperTest.java
+++ b/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/ServiceDefinitionMapperTest.java
@@ -1,0 +1,153 @@
+package org.springframework.cloud.appbroker.autoconfigure;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.cloudfoundry.client.v2.Metadata;
+import org.cloudfoundry.client.v2.serviceplans.ServicePlanEntity;
+import org.cloudfoundry.client.v2.serviceplans.ServicePlanResource;
+import org.cloudfoundry.client.v2.services.ServiceEntity;
+import org.cloudfoundry.client.v2.services.ServiceResource;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.cloud.servicebroker.model.catalog.Plan;
+import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ServiceDefinitionMapperTest {
+
+	@Test
+	void filtersOutServiceEntityMatchingExcludeRegexp() {
+		assertEntityIsFiltered(".*exclude", "brokerNameTo_exclude", false);
+	}
+
+	@Test
+	void filtersInServiceEntityNotMatchingExcludeRegexp() {
+		assertEntityIsFiltered(".*exclude", "brokerNameTo_include", true);
+	}
+
+	@Test
+	void filtersInAllServiceEntitiesWhenNoRegexpConfigured() {
+		assertEntityIsFiltered(null, "a random brokerName", true);
+	}
+
+	private void assertEntityIsFiltered(String excludeBrokerNamesRegexp, String serviceBrokerName,
+		boolean shouldMapEntity) {
+		//given
+		ServiceDefinitionMapperProperties serviceDefinitionMapperProperties = new ServiceDefinitionMapperProperties();
+		serviceDefinitionMapperProperties.setExcludeBrokerNamesRegexp(excludeBrokerNamesRegexp);
+		PlanMapper planMapper = mock(PlanMapper.class);
+		ServiceDefinitionMapper serviceDefinitionMapper = new ServiceDefinitionMapper(
+			planMapper, serviceDefinitionMapperProperties);
+
+		//when
+		ServiceEntity entity = ServiceEntity.builder()
+			.serviceBrokerName(serviceBrokerName)
+			.build();
+
+		//then
+		assertThat(serviceDefinitionMapper.shouldMapServiceEntity(entity)).isEqualTo(shouldMapEntity);
+	}
+
+	@Test
+	void mapsToServiceDefinition() {
+		//given
+		ServiceResource resource = aServiceResource();
+		List<ServicePlanResource> servicePlans = singletonList(aServicePlanResource());
+
+		PlanMapper planMapper = mock(PlanMapper.class);
+		List<Plan> expectedPlans = singletonList(anExpectedPlan());
+		when(planMapper.toPlans(any())).thenReturn(expectedPlans);
+		ServiceDefinitionMapper serviceDefinitionMapper = new ServiceDefinitionMapper(
+			planMapper, new ServiceDefinitionMapperProperties());
+
+		//when
+		ServiceDefinition serviceDefinition = serviceDefinitionMapper.toServiceDefinition(resource, servicePlans);
+
+		//then
+		ServiceDefinition expectedServiceDefinition= anExpectedServiceDefinition(expectedPlans, "");
+		assertThat(serviceDefinition).isEqualTo(expectedServiceDefinition);
+	}
+
+	@Test
+	void addsSuffixToServiceNamesWhenAsked() {
+		//given
+		ServiceResource resource = aServiceResource();
+		List<ServicePlanResource> servicePlans = singletonList(aServicePlanResource());
+
+		PlanMapper planMapper = mock(PlanMapper.class);
+		List<Plan> expectedPlans = singletonList(anExpectedPlan());
+		when(planMapper.toPlans(any())).thenReturn(expectedPlans);
+		ServiceDefinitionMapperProperties serviceDefinitionMapperProperties = new ServiceDefinitionMapperProperties();
+		serviceDefinitionMapperProperties.setSuffix("-cmdb");
+		ServiceDefinitionMapper serviceDefinitionMapper = new ServiceDefinitionMapper(
+			planMapper, serviceDefinitionMapperProperties);
+
+		//when
+		ServiceDefinition serviceDefinition = serviceDefinitionMapper.toServiceDefinition(resource, servicePlans);
+
+		//then
+		ServiceDefinition expectedServiceDefinition= anExpectedServiceDefinition(expectedPlans, "-cmdb");
+		assertThat(serviceDefinition).isEqualTo(expectedServiceDefinition);
+	}
+
+
+
+	private ServiceResource aServiceResource() {
+		return ServiceResource.builder()
+			.metadata(Metadata.builder()
+				.id("service-id")
+				.build())
+			.entity(ServiceEntity.builder()
+				.label("service-name")
+				.description("service-description")
+				.extra("{}")
+				.serviceBrokerName("broker-name")
+				.build())
+			.build();
+	}
+
+	private ServiceDefinition anExpectedServiceDefinition(List<Plan> expectedPlans, String serviceNameSuffix) {
+		return ServiceDefinition
+			.builder()
+			.id("service-id")
+			.description("service-description")
+			.name("service-name" + serviceNameSuffix)
+			.bindable(false)
+			.planUpdateable(false)
+			.bindingsRetrievable(false)
+			.instancesRetrievable(false)
+			.tags(Collections.emptyList())
+			.plans(expectedPlans)
+			.metadata(Collections.emptyMap())
+			.build();
+	}
+
+	private ServicePlanResource aServicePlanResource() {
+		return ServicePlanResource.builder()
+			.entity(ServicePlanEntity.builder()
+				.name("plan-name")
+				.description("plan-description")
+				.build())
+			.metadata(Metadata.builder()
+				.id("plan-id")
+				.build())
+			.build();
+	}
+
+	private Plan anExpectedPlan() {
+		return Plan.builder()
+			.id("plan-id")
+			.name("plan-name")
+			.description("plan-description")
+			.metadata(Collections.emptyMap())
+			.free(false)
+			.build();
+	}
+
+}

--- a/spring-cloud-app-broker-autoconfigure/src/test/resources/logback.xml
+++ b/spring-cloud-app-broker-autoconfigure/src/test/resources/logback.xml
@@ -1,4 +1,4 @@
-<configuration>
+<configuration debug="true">
 
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
@@ -8,7 +8,11 @@
 		</encoder>
 	</appender>
 
-	<root level="info">
+	<root level="DEBUG">
 		<appender-ref ref="STDOUT"/>
 	</root>
+<!--	<logger name="org.springframework.boot.autoconfigure.logging.ConditionEvaluationReportLoggingListener" level="DEBUG" />-->
+	<logger name="org.springframework" level="TRACE" />
+<!--	<logger name="org.springframework.boot" level="TRACE" />-->
+<!--	<logger name="org.springframework.boot.autoconfigure" level="DEBUG" />-->
 </configuration>

--- a/spring-cloud-app-broker-integration-tests/src/test/java/org.springframework.cloud.appbroker/integration/DynamicCatalogComponentTest.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org.springframework.cloud.appbroker/integration/DynamicCatalogComponentTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.integration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(
+	webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+	classes = {AppBrokerApplication.class})
+@ActiveProfiles({"openservicebroker-catalog", "appbroker-cf"})
+class DynamicCatalogComponentTest {
+
+	private String baseUrl;
+
+	@Value("${local.server.port}")
+	private String port;
+
+	@BeforeEach
+	void setUp() {
+		baseUrl = "http://localhost:" + port;
+	}
+
+	@Test
+	void shouldRetrieveCatalog() {
+		given()
+			.get(baseUrl + "/v2/catalog")
+			.then()
+			.statusCode(HttpStatus.OK.value())
+			.body("services[0].name", equalTo("example"))
+			.body("services[0].description", equalTo("A simple example"))
+			.body("services[0].bindable", equalTo(true))
+			.body("services[0].metadata.size()", is(0))
+			.body("services[0].plan_updateable", equalTo(null))
+			.body("services[0].instances_retrievable", equalTo(null))
+			.body("services[0].plans[0].id", equalTo("standard-plan-id"))
+			.body("services[0].plans[0].name", equalTo("standard"))
+			.body("services[0].plans[0].metadata", equalTo(null))
+			.body("services[0].plans[0].bindable", equalTo(true))
+			.body("services[0].plans[0].free", equalTo(true))
+			.body("services[0].plans[0].description", equalTo("A simple plan"));
+	}
+
+}
+

--- a/spring-cloud-app-broker-integration-tests/src/test/java/org.springframework.cloud.appbroker/integration/DynamicServiceAutoConfigurationComponentTest.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org.springframework.cloud.appbroker/integration/DynamicServiceAutoConfigurationComponentTest.java
@@ -1,0 +1,281 @@
+package org.springframework.cloud.appbroker.integration;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jdk.nashorn.internal.ir.annotations.Ignore;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.appbroker.autoconfigure.DynamicCatalogConstants;
+import org.springframework.cloud.appbroker.autoconfigure.DynamicCatalogServiceAutoConfiguration;
+import org.springframework.cloud.appbroker.autoconfigure.ServiceDefinitionMapperProperties;
+import org.springframework.cloud.appbroker.deployer.BrokeredServices;
+import org.springframework.cloud.appbroker.integration.fixtures.CloudControllerStubFixture;
+import org.springframework.cloud.appbroker.integration.fixtures.CloudFoundryClientConfiguration;
+import org.springframework.cloud.appbroker.integration.fixtures.CredHubStubFixture;
+import org.springframework.cloud.appbroker.integration.fixtures.ExtendedCloudControllerStubFixture;
+import org.springframework.cloud.appbroker.integration.fixtures.OpenServiceBrokerApiFixture;
+import org.springframework.cloud.appbroker.integration.fixtures.TargetPropertiesConfiguration;
+import org.springframework.cloud.appbroker.integration.fixtures.TestBindingCredentialsProviderFixture;
+import org.springframework.cloud.appbroker.integration.fixtures.UaaStubFixture;
+import org.springframework.cloud.appbroker.integration.fixtures.WiremockServerFixture;
+import org.springframework.cloud.servicebroker.model.catalog.Catalog;
+import org.springframework.cloud.servicebroker.model.catalog.Plan;
+import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+@ExtendWith(SpringExtension.class) //Junit 5 jupiter support
+@ContextConfiguration(classes = {
+	WiremockServerFixture.class,
+	OpenServiceBrokerApiFixture.class,
+	ExtendedCloudControllerStubFixture.class,
+	UaaStubFixture.class,
+	CredHubStubFixture.class,
+	TestBindingCredentialsProviderFixture.class})
+@TestPropertySource(properties = {
+	"spring.cloud.appbroker.deployer.cloudfoundry.api-host=localhost",
+	"spring.cloud.appbroker.deployer.cloudfoundry.api-port=8080",
+	"spring.cloud.appbroker.deployer.cloudfoundry.username=admin",
+	"spring.cloud.appbroker.deployer.cloudfoundry.password=adminpass",
+	"spring.cloud.appbroker.deployer.cloudfoundry.default-org=test",
+	"spring.cloud.appbroker.deployer.cloudfoundry.default-space=development",
+	"spring.cloud.appbroker.deployer.cloudfoundry.secure=false"
+})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS) //throw away wiremock across each test
+class DynamicServiceAutoConfigurationComponentTest {
+
+	private final Logger logger = LoggerFactory.getLogger(getClass());
+
+	@Autowired
+	private WiremockServerFixture wiremockFixture;
+
+	@Autowired
+	private ExtendedCloudControllerStubFixture cloudControllerFixture;
+
+	@Autowired
+	private CloudControllerStubFixture cloudFoundryFixture;
+
+
+	@Autowired
+	private UaaStubFixture uaaFixture;
+
+	@BeforeAll
+	void setUp() {
+		wiremockFixture.startWiremock();
+	}
+
+	@AfterAll
+	void tearDown() {
+		wiremockFixture.stopWiremock();
+	}
+
+	@BeforeEach
+	void resetWiremock() {
+		wiremockFixture.resetWiremock();
+
+		uaaFixture.stubCommonUaaRequests();
+		cloudFoundryFixture.stubCommonCloudControllerRequests();
+	}
+
+	@AfterEach
+	void verifyStubs() {
+		wiremockFixture.verifyAllRequiredStubsUsed();
+	}
+
+	private final ApplicationContextRunner contextRunner = setUpCommonApplicationContextRunner("");
+
+	private ApplicationContextRunner setUpCommonApplicationContextRunner(String extraProperty) {
+		return new ApplicationContextRunner()
+			.withPropertyValues(
+				"spring.cloud.appbroker.acceptancetest.cloudfoundry.api-host=localhost",
+				"spring.cloud.appbroker.acceptancetest.cloudfoundry.api-port=8080",
+				"spring.cloud.appbroker.acceptancetest.cloudfoundry.username=admin",
+				"spring.cloud.appbroker.acceptancetest.cloudfoundry.password=adminpass",
+				"spring.cloud.appbroker.acceptancetest.cloudfoundry.default-org=test",
+				"spring.cloud.appbroker.acceptancetest.cloudfoundry.default-space=development",
+				"spring.cloud.appbroker.acceptancetest.cloudfoundry.secure=false",
+				"spring.cloud.appbroker.acceptance-test.cloudfoundry.client-id=osb-cmdb-acceptance-test",
+				"spring.cloud.appbroker.acceptance-test.cloudfoundry.client-secret=IPN4500Bgf0fQhZrA0CBpIovYzAyhln",
+				DynamicCatalogConstants.OPT_IN_PROPERTY+"=true",
+				extraProperty)
+			.withConfiguration(AutoConfigurations.of(
+				TargetPropertiesConfiguration.class,
+				CloudFoundryClientConfiguration.class,
+				DynamicCatalogServiceAutoConfiguration.class
+			));
+	}
+
+	@Test
+	void catalogCreatedWithDetailedValidMetadata() {
+		cloudControllerFixture.stubSpaceServiceWithResponse("list-space-services-detailed");
+		cloudControllerFixture.stubServicePlanWithResponse("list-service-plans-detailed");
+
+		this.contextRunner
+			.run(context -> {
+				assertThat(context).hasSingleBean(BrokeredServices.class);
+				BrokeredServices brokeredServices = context.getBean(BrokeredServices.class);
+				assertThat(brokeredServices).isNotEmpty();
+
+				assertThat(context).hasSingleBean(Catalog.class);
+				Catalog catalog = context.getBean(Catalog.class);
+				assertThat(catalog.getServiceDefinitions()).isNotEmpty();
+				ServiceDefinition serviceDefinition = catalog.getServiceDefinitions().get(0);
+				assertThat(serviceDefinition.getName()).isEqualTo("db-service");
+				assertThat(serviceDefinition.getDescription()).isEqualTo("My DB Service");
+				assertThat(serviceDefinition.isBindable()).isTrue(); //Non default value
+				assertThat(serviceDefinition.isPlanUpdateable()).isTrue(); //Non default value
+				assertThat(serviceDefinition.isInstancesRetrievable()).isTrue(); //Non default value
+				assertThat(serviceDefinition.getTags()).containsOnly("tag1", "tag2");
+				
+				Map<String, Object> metadata = serviceDefinition.getMetadata();
+				assertThat(metadata)
+					.isNotNull()
+					.isNotEmpty()
+					.containsOnly(
+						entry("displayName", "displayName"),
+						entry("longDescription", "longDescription")
+						);
+				assertThat(serviceDefinition.getPlans().size()).isEqualTo(1);
+				Plan plan = serviceDefinition.getPlans().get(0);
+
+				logger.info("schemas: {}", plan.getSchemas());
+				assertThat(plan.getSchemas()).isNotNull();
+				assertThat(plan.getSchemas().getServiceInstanceSchema()).isNotNull();
+				assertThat(plan.getSchemas().getServiceInstanceSchema().getCreateMethodSchema()).isNotNull();
+				assertThat(plan.getSchemas().getServiceInstanceSchema().getCreateMethodSchema().getParameters().size()).isEqualTo(3); //$schema, type, properties
+				assertThat(plan.getSchemas().getServiceInstanceSchema().getCreateMethodSchema().getParameters().size()).isEqualTo(3); //$schema, type, properties
+				//noinspection unchecked
+				Map<String, Object> properties = (Map<String, Object>) plan.getSchemas().getServiceInstanceSchema().getCreateMethodSchema().getParameters().get("properties");
+				assertThat(properties.get("baz")).isNotNull(); //$schema, type, properties
+				assertThat(plan.getSchemas().getServiceInstanceSchema().getUpdateMethodSchema()).isNotNull();
+				assertThat(plan.getSchemas().getServiceInstanceSchema().getUpdateMethodSchema().getParameters().size()).isEqualTo(3);
+				assertThat(plan.getSchemas().getServiceBindingSchema().getCreateMethodSchema()).isNotNull();
+				assertThat(plan.getSchemas().getServiceBindingSchema().getCreateMethodSchema().getParameters().size()).isEqualTo(3);
+
+				assertThat(plan.getMetadata()).isNotEmpty();
+				assertThat(plan.getMetadata().get("costs")).isNotNull();
+			});
+	}
+	@Test
+	void catalogCreatedWithNullMetadata() {
+		cloudControllerFixture.stubSpaceServiceWithResponse("list-space-services-null-extra");
+		cloudControllerFixture.stubServicePlanWithResponse("list-service-plans");
+		assertCatalogCreatesWithoutError();
+	}
+
+	@Test
+	void catalogCreatedWithSimpleMetadata() {
+		cloudControllerFixture.stubSpaceServiceWithResponse("list-space-services");
+		cloudControllerFixture.stubServicePlanWithResponse("list-service-plans");
+		assertCatalogCreatesWithoutError();
+	}
+
+	@Test
+	void excludesBrokersMatchingRegexp() {
+		//Given a marketplace with 2 service definition
+		aStubbedMarketplaceWithTwoServiceOfferings();
+
+		//And a broker exclusion regexp configrued
+		String extraProperty = ServiceDefinitionMapperProperties.PROPERTY_PREFIX
+			+ ServiceDefinitionMapperProperties.EXCLUDE_BROKER_PROPERTY_KEY
+			+ "=service_broker_name2";
+		ApplicationContextRunner customContextRunner = setUpCommonApplicationContextRunner(extraProperty);
+
+		//when fetching marketplace
+		customContextRunner
+			.run(context -> {
+				//then
+				BrokeredServices brokeredServices = context.getBean(BrokeredServices.class);
+				assertThat(brokeredServices).hasSize(1);
+
+				Catalog catalog = context.getBean(Catalog.class);
+				assertThat(catalog.getServiceDefinitions()).hasSize(1);
+			});
+	}
+
+	private void aStubbedMarketplaceWithTwoServiceOfferings() {
+		cloudControllerFixture.stubSpaceServiceWithResponse("list-space-services-multiple");
+		cloudControllerFixture.stubServicePlanWithResponse("list-service-plans-detailed", "SERVICE-ID");
+		cloudControllerFixture.stubServicePlanWithResponse("list-service-plans-service2", "SERVICE-ID2");
+	}
+
+	@Test
+	void doesNotExcludeBrokersNotMatchingRegexp() {
+		//Given a marketplace with 2 service definition
+		aStubbedMarketplaceWithTwoServiceOfferings();
+
+		//And a broker exclusion regexp configrued
+		String extraProperty = ServiceDefinitionMapperProperties.PROPERTY_PREFIX
+			+ ServiceDefinitionMapperProperties.EXCLUDE_BROKER_PROPERTY_KEY
+			+ "=non_matching_broker_name";
+		ApplicationContextRunner customContextRunner = setUpCommonApplicationContextRunner(extraProperty);
+
+		//when fetching marketplace
+		customContextRunner
+			.run(context -> {
+				//then
+				BrokeredServices brokeredServices = context.getBean(BrokeredServices.class);
+				assertThat(brokeredServices).hasSize(2);
+
+				Catalog catalog = context.getBean(Catalog.class);
+				assertThat(catalog.getServiceDefinitions()).hasSize(2);
+			});
+	}
+
+	private void assertCatalogCreatesWithoutError() {
+		this.contextRunner
+			.run(context -> {
+				BrokeredServices brokeredServices = context.getBean(BrokeredServices.class);
+				assertThat(brokeredServices).isNotEmpty();
+
+				Catalog catalog = context.getBean(Catalog.class);
+				List<ServiceDefinition> serviceDefinitions = catalog.getServiceDefinitions();
+				assertThat(serviceDefinitions).isNotEmpty();
+				serviceDefinitions.stream()
+					.map(ServiceDefinition::getPlans)
+					.flatMap(Collection::stream)
+					.forEach(this::assertPlanSerializesWithoutPollutingWithNulls);
+			});
+	}
+
+	private void assertPlanSerializesWithoutPollutingWithNulls(Plan plan)  {
+		try {
+			ObjectMapper mapper = new ObjectMapper();
+			String serializedPlan = mapper.writeValueAsString(plan);
+			logger.info("serializedPlan {}", serializedPlan);
+			assertThat(serializedPlan).doesNotContain(":null");
+			assertThat(serializedPlan).doesNotContain("\"parameters\": {}");
+		}
+		catch (JsonProcessingException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+
+	@Test
+	@Ignore
+		//Not yet implemented
+	void catalogFetchingFailuresThrowsException() {
+		//TODO: fail if the flux contains error events (was the case when Jackson was not configured to ignore
+	}
+
+}

--- a/spring-cloud-app-broker-integration-tests/src/test/java/org.springframework.cloud.appbroker/integration/fixtures/CloudFoundryClientConfiguration.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org.springframework.cloud.appbroker/integration/fixtures/CloudFoundryClientConfiguration.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.integration.fixtures;
+
+import java.util.Optional;
+
+import org.cloudfoundry.client.CloudFoundryClient;
+import org.cloudfoundry.doppler.DopplerClient;
+import org.cloudfoundry.operations.CloudFoundryOperations;
+import org.cloudfoundry.operations.DefaultCloudFoundryOperations;
+import org.cloudfoundry.reactor.ConnectionContext;
+import org.cloudfoundry.reactor.DefaultConnectionContext;
+import org.cloudfoundry.reactor.TokenProvider;
+import org.cloudfoundry.reactor.client.ReactorCloudFoundryClient;
+import org.cloudfoundry.reactor.doppler.ReactorDopplerClient;
+import org.cloudfoundry.reactor.tokenprovider.ClientCredentialsGrantTokenProvider;
+import org.cloudfoundry.reactor.tokenprovider.PasswordGrantTokenProvider;
+import org.cloudfoundry.reactor.uaa.ReactorUaaClient;
+import org.cloudfoundry.uaa.UaaClient;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(CloudFoundryProperties.class)
+//Inspired from spring-cloud-app-broker-acceptance-tests
+public class CloudFoundryClientConfiguration {
+
+	public static final String APP_BROKER_CLIENT_SECRET = "app-broker-client-secret";
+	public static final String[] APP_BROKER_CLIENT_AUTHORITIES = {
+		"cloud_controller.read", "cloud_controller.write", "clients.write"
+	};
+
+	@Bean
+	CloudFoundryOperations cloudFoundryOperations(CloudFoundryProperties properties,
+												  CloudFoundryClient client,
+												  DopplerClient dopplerClient,
+												  UaaClient uaaClient) {
+		return DefaultCloudFoundryOperations.builder()
+			.cloudFoundryClient(client)
+			.dopplerClient(dopplerClient)
+			.uaaClient(uaaClient)
+			.organization(properties.getDefaultOrg())
+			.space(properties.getDefaultSpace())
+			.build();
+	}
+
+	@Bean
+	CloudFoundryClient cloudFoundryClient(ConnectionContext connectionContext,
+										  @Qualifier("userCredentials") TokenProvider tokenProvider) {
+		return ReactorCloudFoundryClient.builder()
+			.connectionContext(connectionContext)
+			.tokenProvider(tokenProvider)
+			.build();
+	}
+
+	@Bean
+	ConnectionContext connectionContext(CloudFoundryProperties properties) {
+		return DefaultConnectionContext.builder()
+			.apiHost(properties.getApiHost())
+			.port(Optional.ofNullable(properties.getApiPort()))
+			.skipSslValidation(properties.isSkipSslValidation())
+			.secure(properties.isSecure())
+			.build();
+	}
+
+	@Bean
+	DopplerClient dopplerClient(ConnectionContext connectionContext,
+								@Qualifier("userCredentials") TokenProvider tokenProvider) {
+		return ReactorDopplerClient.builder()
+			.connectionContext(connectionContext)
+			.tokenProvider(tokenProvider)
+			.build();
+	}
+
+	@Bean
+	UaaClient uaaClient(ConnectionContext connectionContext,
+						@Qualifier("clientCredentials") TokenProvider tokenProvider) {
+		return ReactorUaaClient.builder()
+			.connectionContext(connectionContext)
+			.tokenProvider(tokenProvider)
+			.build();
+	}
+
+	@Bean
+	@Qualifier("userCredentials")
+	@ConditionalOnProperty({
+		CloudFoundryProperties.PROPERTY_PREFIX + ".username",
+		CloudFoundryProperties.PROPERTY_PREFIX + ".password"
+	})
+	PasswordGrantTokenProvider passwordTokenProvider(CloudFoundryProperties properties) {
+		return PasswordGrantTokenProvider.builder()
+			.password(properties.getPassword())
+			.username(properties.getUsername())
+			.build();
+	}
+
+	@Bean
+	@Qualifier("clientCredentials")
+	@ConditionalOnProperty({
+		CloudFoundryProperties.PROPERTY_PREFIX + ".client-id",
+		CloudFoundryProperties.PROPERTY_PREFIX + ".client-secret"
+	})
+	ClientCredentialsGrantTokenProvider clientTokenProvider(CloudFoundryProperties properties) {
+		return ClientCredentialsGrantTokenProvider.builder()
+			.clientId(properties.getClientId())
+			.clientSecret(properties.getClientSecret())
+			.identityZoneSubdomain(properties.getIdentityZoneSubdomain())
+			.build();
+	}
+
+}

--- a/spring-cloud-app-broker-integration-tests/src/test/java/org.springframework.cloud.appbroker/integration/fixtures/CloudFoundryProperties.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org.springframework.cloud.appbroker/integration/fixtures/CloudFoundryProperties.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.integration.fixtures;
+
+import java.net.URI;
+
+import org.cloudfoundry.reactor.ProxyConfiguration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import static org.springframework.cloud.appbroker.integration.fixtures.TargetPropertiesConfiguration.PROPERTY_PREFIX;
+
+
+@ConfigurationProperties(PROPERTY_PREFIX)
+//Inspired from spring-cloud-app-broker-acceptance-tests
+public class CloudFoundryProperties {
+
+	static final String PROPERTY_PREFIX = "spring.cloud.appbroker.acceptancetest.cloudfoundry";
+
+	private String apiHost;
+	private Integer apiPort;
+	private String defaultOrg;
+	private String defaultSpace;
+	private String username;
+	private String password;
+	private String clientId;
+	private String clientSecret;
+	private String identityZoneSubdomain;
+	private boolean secure = true;
+	private boolean skipSslValidation;
+
+	public String getApiHost() {
+		return apiHost;
+	}
+
+	public void setApiHost(String apiHost) {
+		this.apiHost = parseApiHost(apiHost);
+	}
+
+	public Integer getApiPort() {
+		return apiPort;
+	}
+
+	public void setApiPort(int apiPort) {
+		this.apiPort = apiPort;
+	}
+
+	public String getDefaultOrg() {
+		return defaultOrg;
+	}
+
+	public void setDefaultOrg(String defaultOrg) {
+		this.defaultOrg = defaultOrg;
+	}
+
+	public String getDefaultSpace() {
+		return defaultSpace;
+	}
+
+	public void setDefaultSpace(String defaultSpace) {
+		this.defaultSpace = defaultSpace;
+	}
+
+	public String getUsername() {
+		return username;
+	}
+
+	public void setUsername(String username) {
+		this.username = username;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+
+	public String getClientId() {
+		return clientId;
+	}
+
+	public void setClientId(String clientId) {
+		this.clientId = clientId;
+	}
+
+	public String getClientSecret() {
+		return clientSecret;
+	}
+
+	public void setClientSecret(String clientSecret) {
+		this.clientSecret = clientSecret;
+	}
+
+	public String getIdentityZoneSubdomain() {
+		return identityZoneSubdomain;
+	}
+
+	public void setIdentityZoneSubdomain(String identityZoneSubdomain) {
+		this.identityZoneSubdomain = identityZoneSubdomain;
+	}
+
+	public ProxyConfiguration getProxyConfiguration() {
+		return null;
+	}
+
+	public boolean isSecure() {
+		return secure;
+	}
+
+	public void setSecure(boolean secure) {
+		this.secure = secure;
+	}
+
+	public boolean isSkipSslValidation() {
+		return skipSslValidation;
+	}
+
+	public void setSkipSslValidation(boolean skipSslValidation) {
+		this.skipSslValidation = skipSslValidation;
+	}
+
+	private static String parseApiHost(String api) {
+		final URI uri = URI.create(api);
+		return uri.getHost() == null ? api : uri.getHost();
+	}
+
+}

--- a/spring-cloud-app-broker-integration-tests/src/test/java/org.springframework.cloud.appbroker/integration/fixtures/ExtendedCloudControllerStubFixture.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org.springframework.cloud.appbroker/integration/fixtures/ExtendedCloudControllerStubFixture.java
@@ -1,0 +1,29 @@
+package org.springframework.cloud.appbroker.integration.fixtures;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+
+public class ExtendedCloudControllerStubFixture extends CloudControllerStubFixture {
+
+	public void stubSpaceServiceWithResponse(String responseFile) {
+		stubFor(get(urlPathEqualTo("/v2/spaces/" + TEST_SPACE_GUID + "/services"))
+			.withQueryParam("page", equalTo("1"))
+			.willReturn(ok()
+				.withBody(cc(responseFile))));
+	}
+
+	public void stubServicePlanWithResponse(String responseFile) {
+		stubServicePlanWithResponse(responseFile, "SERVICE-ID");
+	}
+
+	public void stubServicePlanWithResponse(String responseFile, String serviceGuid) {
+		stubFor(get(urlPathEqualTo("/v2/service_plans"))
+			.withQueryParam("q", equalTo("service_guid:"+ serviceGuid))
+			.withQueryParam("page", equalTo("1"))
+			.willReturn(ok()
+				.withBody(cc(responseFile))));
+	}
+
+}

--- a/spring-cloud-app-broker-integration-tests/src/test/java/org.springframework.cloud.appbroker/integration/fixtures/TargetPropertiesConfiguration.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org.springframework.cloud.appbroker/integration/fixtures/TargetPropertiesConfiguration.java
@@ -1,0 +1,29 @@
+package org.springframework.cloud.appbroker.integration.fixtures;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.appbroker.deployer.cloudfoundry.CloudFoundryDeploymentProperties;
+import org.springframework.cloud.appbroker.deployer.cloudfoundry.CloudFoundryTargetProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TargetPropertiesConfiguration {
+
+	//Inspired from spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/CloudFoundryAppDeployerAutoConfiguration.java
+	static final String PROPERTY_PREFIX = "spring.cloud.appbroker.acceptancetest.cloudfoundry";
+
+	@Bean
+	@ConfigurationProperties(PROPERTY_PREFIX)
+	CloudFoundryTargetProperties cloudFoundryTargetProperties() {
+		return new CloudFoundryTargetProperties();
+	}
+
+
+	//Inspired from spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/CloudFoundryAppDeployerAutoConfiguration.java
+	@Bean
+	@ConfigurationProperties(PROPERTY_PREFIX + ".properties")
+	CloudFoundryDeploymentProperties cloudFoundryDeploymentProperties() {
+		return new CloudFoundryDeploymentProperties();
+	}
+
+}

--- a/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/fixtures/CloudControllerStubFixture.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/fixtures/CloudControllerStubFixture.java
@@ -39,8 +39,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 @TestComponent
 public class CloudControllerStubFixture extends WiremockStubFixture {
 
-	private static final String TEST_SPACE_GUID = "TEST-SPACE-GUID";
-
+	protected static final String TEST_SPACE_GUID = "TEST-SPACE-GUID";
 	private static final String TEST_ORG_GUID = "TEST-ORG-GUID";
 
 	private static final String TEST_QUOTA_DEFINITION_GUID = "TEST-QUOTA-DEFINITION-GUID";
@@ -568,7 +567,7 @@ public class CloudControllerStubFixture extends WiremockStubFixture {
 					replace("@name", spaceName)))));
 	}
 
-	private String cc(String fileRoot, StringReplacementPair... replacements) {
+	protected String cc(String fileRoot, StringReplacementPair... replacements) {
 		String response = readResponseFromFile(fileRoot, "cloudcontroller");
 		for (StringReplacementPair pair : replacements) {
 			response = response.replaceAll(pair.getRegex(), pair.getReplacement());

--- a/spring-cloud-app-broker-integration-tests/src/test/resources/responses/cloudcontroller/list-service-plans-detailed.json
+++ b/spring-cloud-app-broker-integration-tests/src/test/resources/responses/cloudcontroller/list-service-plans-detailed.json
@@ -1,0 +1,127 @@
+{
+	"total_results": 1,
+	"total_pages": 1,
+	"prev_url": null,
+	"next_url": null,
+	"resources": [
+		{
+			"metadata": {
+				"guid": "SERVICE-PLAN-ID",
+				"url": "/v2/service_plans/SERVICE-PLAN-ID",
+				"created_at": "2018-01-26T20:48:20Z",
+				"updated_at": "2018-06-11T18:08:05Z"
+			},
+			"entity": {
+				"name": "standard",
+				"free": true,
+				"description": "basic",
+				"service_guid": "SERVICE-ID",
+				"extra": "{\n\t\t\t\t\t\t\"bullets\":[\n\t\t\t\t\t\t\t\"20 GB of messages\",\n\t\t\t\t\t\t\t\"20 connections\"\n\t\t\t\t\t\t],\n\t\t\t\t\t\t\"costs\":[\n\t\t\t\t\t\t\t{\n\t\t\t\t\t\t\t\t\"amount\":{\n\t\t\t\t\t\t\t\t\t\"usd\":99.0\n\t\t\t\t\t\t\t\t},\n\t\t\t\t\t\t\t\t\"unit\":\"MONTHLY\"\n\t\t\t\t\t\t\t},\n\t\t\t\t\t\t\t{\n\t\t\t\t\t\t\t\t\"amount\":{\n\t\t\t\t\t\t\t\t\t\"usd\":0.99\n\t\t\t\t\t\t\t\t},\n\t\t\t\t\t\t\t\t\"unit\":\"1GB of messages over 20GB\"\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t],\n\t\t\t\t\t\t\"displayName\":\"Big Bunny\"\n\t\t\t\t\t}\n",
+				"public": true,
+				"bindable": true,
+				"active": true,
+				"service_url": "/v2/services/SERVICE-ID",
+				"service_instances_url": "/v2/service_plans/SERVICE-PLAN-ID/service_instances",
+				"schemas": {
+					"service_binding": {
+						"create": {
+							"parameters": {
+								"$schema": "http://json-schema.org/draft-04/schema#",
+								"type": "object",
+								"properties": {
+									"baz": {
+										"type": "object",
+										"properties": {
+											"foo": {
+												"type": "string"
+											},
+											"bar": {
+												"type": "string"
+											}
+										},
+										"allOf": [
+											{
+												"required": [
+													"foo"
+												]
+											},
+											{
+												"required": [
+													"bar"
+												]
+											}
+										]
+									}
+								}
+							}
+						}
+					},
+					"service_instance": {
+						"create": {
+							"parameters": {
+								"$schema": "http://json-schema.org/draft-04/schema#",
+								"type": "object",
+								"properties": {
+									"baz": {
+										"type": "object",
+										"properties": {
+											"foo": {
+												"type": "string"
+											},
+											"bar": {
+												"type": "string"
+											}
+										},
+										"allOf": [
+											{
+												"required": [
+													"foo"
+												]
+											},
+											{
+												"required": [
+													"bar"
+												]
+											}
+										]
+									}
+								}
+							}
+						},
+						"update": {
+							"parameters": {
+								"$schema": "http://json-schema.org/draft-04/schema#",
+								"type": "object",
+								"properties": {
+									"baz": {
+										"type": "object",
+										"properties": {
+											"foo": {
+												"type": "string"
+											},
+											"bar": {
+												"type": "string"
+											}
+										},
+										"allOf": [
+											{
+												"required": [
+													"foo"
+												]
+											},
+											{
+												"required": [
+													"bar"
+												]
+											}
+										]
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	]
+}

--- a/spring-cloud-app-broker-integration-tests/src/test/resources/responses/cloudcontroller/list-service-plans-service2.json
+++ b/spring-cloud-app-broker-integration-tests/src/test/resources/responses/cloudcontroller/list-service-plans-service2.json
@@ -1,0 +1,43 @@
+{
+	"total_results": 1,
+	"total_pages": 1,
+	"prev_url": null,
+	"next_url": null,
+	"resources": [
+		{
+			"metadata": {
+				"guid": "SERVICE-PLAN-ID-2",
+				"url": "/v2/service_plans/SERVICE-PLAN-ID-2",
+				"created_at": "2018-01-26T20:48:20Z",
+				"updated_at": "2018-06-11T18:08:05Z"
+			},
+			"entity": {
+				"name": "standard-2",
+				"free": true,
+				"description": "basic-2",
+				"service_guid": "SERVICE-ID2",
+				"extra": "{}",
+				"public": true,
+				"bindable": true,
+				"active": true,
+				"service_url": "/v2/services/SERVICE-ID2",
+				"service_instances_url": "/v2/service_plans/SERVICE-PLAN-ID-2/service_instances",
+				"schemas": {
+					"service_instance": {
+						"create": {
+							"parameters": {}
+						},
+						"update": {
+							"parameters": {}
+						}
+					},
+					"service_binding": {
+						"create": {
+							"parameters": {}
+						}
+					}
+				}
+			}
+		}
+	]
+}

--- a/spring-cloud-app-broker-integration-tests/src/test/resources/responses/cloudcontroller/list-space-services-detailed.json
+++ b/spring-cloud-app-broker-integration-tests/src/test/resources/responses/cloudcontroller/list-space-services-detailed.json
@@ -1,0 +1,42 @@
+{
+	"total_results": 1,
+	"total_pages": 1,
+	"prev_url": null,
+	"next_url": null,
+	"resources": [
+		{
+			"metadata": {
+				"guid": "SERVICE-ID",
+				"url": "/v2/services/SERVICE-ID",
+				"created_at": "2018-01-26T20:48:20Z",
+				"updated_at": "2018-06-11T18:08:05Z"
+			},
+			"entity": {
+				"label": "db-service",
+				"provider": null,
+				"url": null,
+				"description": "My DB Service",
+				"long_description": null,
+				"version": null,
+				"info_url": null,
+				"active": true,
+				"bindable": true,
+				"unique_id": "cassandra-service-broker",
+				"extra": "{\n  \"displayName\": \"displayName\", \"longDescription\": \"longDescription\"}",
+				"tags": [
+					"tag1",
+					"tag2"
+				],
+				"requires": [],
+				"documentation_url": null,
+				"service_broker_guid": "service_broker_guid",
+				"service_broker_name": "service_broker_name",
+				"plan_updateable": true,
+				"bindings_retrievable": true,
+				"instances_retrievable": true,
+				"allow_context_updates": true,
+				"service_plans_url": "/v2/services/SERVICE-ID/service_plans"
+			}
+		}
+	]
+}

--- a/spring-cloud-app-broker-integration-tests/src/test/resources/responses/cloudcontroller/list-space-services-multiple.json
+++ b/spring-cloud-app-broker-integration-tests/src/test/resources/responses/cloudcontroller/list-space-services-multiple.json
@@ -1,0 +1,77 @@
+{
+	"total_results": 1,
+	"total_pages": 1,
+	"prev_url": null,
+	"next_url": null,
+	"resources": [
+		{
+			"metadata": {
+				"guid": "SERVICE-ID",
+				"url": "/v2/services/SERVICE-ID",
+				"created_at": "2018-01-26T20:48:20Z",
+				"updated_at": "2018-06-11T18:08:05Z"
+			},
+			"entity": {
+				"label": "db-service",
+				"provider": null,
+				"url": null,
+				"description": "My DB Service",
+				"long_description": null,
+				"version": null,
+				"info_url": null,
+				"active": true,
+				"bindable": true,
+				"unique_id": "cassandra-service-broker",
+				"extra": "{\n  \"displayName\": \"displayName\", \"longDescription\": \"longDescription\"}",
+				"tags": [
+					"tag1",
+					"tag2"
+				],
+				"requires": [],
+				"documentation_url": null,
+				"service_broker_guid": "service_broker_guid",
+				"service_broker_name": "service_broker_name",
+				"plan_updateable": true,
+				"bindings_retrievable": true,
+				"instances_retrievable": true,
+				"allow_context_updates": true,
+				"service_plans_url": "/v2/services/SERVICE-ID/service_plans"
+			}
+		},
+		{
+			"metadata": {
+				"guid": "SERVICE-ID2",
+				"url": "/v2/services/SERVICE-ID2",
+				"created_at": "2018-01-26T20:48:20Z",
+				"updated_at": "2018-06-11T18:08:05Z"
+			},
+			"entity": {
+				"label": "db-service2",
+				"provider": null,
+				"url": null,
+				"description": "My DB Service2",
+				"long_description": null,
+				"version": null,
+				"info_url": null,
+				"active": true,
+				"bindable": true,
+				"unique_id": "cassandra-service-broker",
+				"extra": "{\n  \"displayName\": \"displayName\", \"longDescription\": \"longDescription\"}",
+				"tags": [
+					"tag1",
+					"tag2"
+				],
+				"requires": [],
+				"documentation_url": null,
+				"service_broker_guid": "service_broker_guid2",
+				"service_broker_name": "service_broker_name2",
+				"plan_updateable": true,
+				"bindings_retrievable": true,
+				"instances_retrievable": true,
+				"allow_context_updates": true,
+				"service_plans_url": "/v2/services/SERVICE-ID2/service_plans"
+			}
+		}
+
+	]
+}

--- a/spring-cloud-app-broker-integration-tests/src/test/resources/responses/cloudcontroller/list-space-services-null-extra.json
+++ b/spring-cloud-app-broker-integration-tests/src/test/resources/responses/cloudcontroller/list-space-services-null-extra.json
@@ -1,0 +1,34 @@
+{
+	"total_results": 1,
+	"total_pages": 1,
+	"prev_url": null,
+	"next_url": null,
+	"resources": [
+		{
+			"metadata": {
+				"guid": "SERVICE-ID",
+				"url": "/v2/services/SERVICE-ID",
+				"created_at": "2018-01-26T20:48:20Z",
+				"updated_at": "2018-06-11T18:08:05Z"
+			},
+			"entity": {
+				"label": "db-service",
+				"provider": null,
+				"url": null,
+				"description": "My DB Service",
+				"long_description": null,
+				"version": null,
+				"info_url": null,
+				"active": 1,
+				"bindable": 1,
+				"extra": null,
+				"tags": [
+				],
+				"requires": [],
+				"documentation_url": null,
+				"plan_updateable": 0,
+				"service_plans_url": "/v2/services/SERVICE-ID/service_plans"
+			}
+		}
+	]
+}


### PR DESCRIPTION
This PR previews a features which provides opt-in for dynamically generated catalog and brokered services fetched from CF default org/space.

Potential use-cases besides #285 :
* As a service operator providing a data service (such as mysql)
* In order to provide a web-ui deployed by scan
* And avoid manual configuration of the catalog and brokered services
* I need SCAB to be able to automatically fetch the mysql service offering as registered in CF and return it as catalog
* And generate a brokered services default configuration template which I can reused in my application.yml

This PR is a work-in-progress, featuring a similar feature implemented in OSB-cmdb and documented at https://github.com/orange-cloudfoundry/osb-cmdb-spike#dynamic-catalog

Goal of this PR is to understand whether there would be interest in such feature in SCAB that could justify generalizing this PR to SCAB use-cases.

Currently, changes in this PR:

* Produces Catalog
   - with a configureable service name suffix
   - with service broker exclusion pattern
* Produces BrokeredService
   - injects target strategy as SpacePerServiceDefinition
* Dumps dynamic catalog to disk at `/tmp/osb-cmdb-dynamicCatalog.yml` as to enable manual edition and inclusion into `application.yml` by operators

Remaining pending work:
* Circle CI build hasn't been worked on (failing on first checkstyle violation, tests were made only pass green in [osb-cmdb-spike/master](https://circleci.com/gh/orange-cloudfoundry/osb-cmdb-spike/tree/master))
* Most of the work is done in the `spring-cloud-app-broker-autoconfigure` module and would need to be spread across `spring-cloud-app-broker-deployer` and `spring-cloud-app-broker-deployer-cloudfoundry`
* The `DynamicServiceAutoConfigurationAcceptanceTest` is misnamed: rather than testing the autoconfiguration starts when directed to a live cloudfoundry instance, and properly producing `Catalog` . It does not assert end-to-end behavior such as /v2/catalog endpoint being properly served nor `BrokeredServices` being used.