### PR TITLE
Replacing InMemory Map data structure

### DIFF
--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/state/InMemoryServiceInstanceBindingStateRepository.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/state/InMemoryServiceInstanceBindingStateRepository.java
@@ -20,18 +20,15 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.servicebroker.model.instance.OperationState;
 
-/**
- * @author Roy Clarkson
- */
 public class InMemoryServiceInstanceBindingStateRepository implements ServiceInstanceBindingStateRepository {
 
-	private final Map<BindingKey, ServiceInstanceState> states = new ConcurrentHashMap<>();
+	private final Map<BindingKey, ServiceInstanceState> states = new ConcurrentSkipListMap<>();
 
 	@Override
 	public Mono<ServiceInstanceState> saveState(String serviceInstanceId, String bindingId, OperationState state,
@@ -76,7 +73,7 @@ public class InMemoryServiceInstanceBindingStateRepository implements ServiceIns
 		return Mono.fromCallable(() -> this.states.containsKey(bindingKey));
 	}
 
-	private static class BindingKey {
+	private static class BindingKey implements Comparable<BindingKey> {
 
 		private final String serviceInstanceId;
 
@@ -119,6 +116,12 @@ public class InMemoryServiceInstanceBindingStateRepository implements ServiceIns
 				"serviceInstanceId='" + serviceInstanceId + '\'' +
 				", bindingId='" + bindingId + '\'' +
 				'}';
+		}
+
+		@Override
+		public int compareTo(BindingKey other) {
+			int compare = this.serviceInstanceId.compareTo(other.serviceInstanceId);
+			return compare == 0 ? this.bindingId.compareTo(other.bindingId) : compare;
 		}
 
 	}

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/state/InMemoryServiceInstanceStateRepository.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/state/InMemoryServiceInstanceStateRepository.java
@@ -19,7 +19,7 @@ package org.springframework.cloud.appbroker.state;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 import reactor.core.publisher.Mono;
 
@@ -27,7 +27,7 @@ import org.springframework.cloud.servicebroker.model.instance.OperationState;
 
 public class InMemoryServiceInstanceStateRepository implements ServiceInstanceStateRepository {
 
-	private final Map<String, ServiceInstanceState> states = new ConcurrentHashMap<>();
+	private final Map<String, ServiceInstanceState> states = new ConcurrentSkipListMap<>();
 
 	@Override
 	public Mono<ServiceInstanceState> saveState(String serviceInstanceId, OperationState state, String description) {

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/state/InMemoryServiceInstanceBindingStateRepositoryTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/state/InMemoryServiceInstanceBindingStateRepositoryTest.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.appbroker.state;
 import java.util.Calendar;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;
@@ -29,8 +28,6 @@ import org.springframework.cloud.servicebroker.model.instance.OperationState;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Disabled
-// See https://github.com/spring-cloud/spring-cloud-app-broker/issues/313
 class InMemoryServiceInstanceBindingStateRepositoryTest {
 
 	private InMemoryServiceInstanceBindingStateRepository stateRepository;

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/state/InMemoryServiceInstanceStateRepositoryTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/state/InMemoryServiceInstanceStateRepositoryTest.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.appbroker.state;
 import java.util.Calendar;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;
@@ -29,8 +28,6 @@ import org.springframework.cloud.servicebroker.model.instance.OperationState;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Disabled
-// See https://github.com/spring-cloud/spring-cloud-app-broker/issues/313
 class InMemoryServiceInstanceStateRepositoryTest {
 
 	private InMemoryServiceInstanceStateRepository stateRepository;


### PR DESCRIPTION
To avoid blocking from time to time: #313 this commit replaces the Map implementation by a ConcurrentSkipListMap, it might not be the most efficient way to store this information, but, considering the order of magnitude we are dealing with and, the fact that the reading time is around logaritmic, should be good enough for this use case.

[Finishes #313]