### PR TITLE
K8s service instances dupls (WIP)

### DIFF
--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/service/WorkflowServiceInstanceService.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/service/WorkflowServiceInstanceService.java
@@ -25,6 +25,7 @@ import reactor.core.scheduler.Schedulers;
 import reactor.util.Logger;
 import reactor.util.Loggers;
 
+import org.springframework.cloud.appbroker.state.ServiceInstanceState;
 import org.springframework.cloud.appbroker.state.ServiceInstanceStateRepository;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceDoesNotExistException;
 import org.springframework.cloud.servicebroker.model.instance.CreateServiceInstanceRequest;
@@ -49,6 +50,19 @@ import org.springframework.core.annotation.AnnotationAwareOrderComparator;
  * operation.
  */
 public class WorkflowServiceInstanceService implements ServiceInstanceService {
+
+	public static final CreateServiceInstanceResponse RESPONSE_CREATE_202_ACCEPTED = CreateServiceInstanceResponse.builder()
+		.async(true)
+		.build();
+
+	public static final UpdateServiceInstanceResponse RESPONSE_UPDATE_202_ACCEPTED =
+		UpdateServiceInstanceResponse.builder()
+		.async(true)
+		.build();
+
+	public static final DeleteServiceInstanceResponse RESPONSE_DELETE_202_ACCEPTED = DeleteServiceInstanceResponse.builder()
+		.async(true)
+		.build();
 
 	private final Logger log = Loggers.getLogger(WorkflowServiceInstanceService.class);
 
@@ -76,10 +90,64 @@ public class WorkflowServiceInstanceService implements ServiceInstanceService {
 
 	@Override
 	public Mono<CreateServiceInstanceResponse> createServiceInstance(CreateServiceInstanceRequest request) {
-		return invokeCreateResponseBuilders(request)
-			.publishOn(Schedulers.parallel())
-			.doOnNext(response -> create(request, response)
-				.subscribe());
+		return
+			emitCreateAcceptedOnConcurrentRequest(request)
+			.switchIfEmpty(
+				stateRepository.saveState(request.getServiceInstanceId(),
+					OperationState.IN_PROGRESS,
+					"create service instance started")
+				.then(
+					invokeCreateResponseBuilders(request)
+						.doOnNext(response -> create(request, response).subscribe())));
+	}
+
+	private Mono<CreateServiceInstanceResponse> emitCreateAcceptedOnConcurrentRequest(CreateServiceInstanceRequest request) {
+		return getCurrentServiceInstanceState(request.getServiceInstanceId())
+			.filter(serviceInstanceState -> OperationState.IN_PROGRESS.equals(serviceInstanceState.getOperationState()))
+			.doOnNext(serviceInstanceState -> {
+				//A provisionning is in progress with the same Id, return 202 Accepted status code
+				//There is a small accepted risk that the operation is not a create, but a update/delete service
+				// instance
+				log.info("Assuming duplicate provisioning request with id={} as one operation is inflight with " +
+						"message={}, " +
+						"returning 202 accepted without " +
+						"triggering a new provisionning workflow", serviceInstanceState.getDescription(),
+					request.getServiceInstanceId());
+			})
+			.map(serviceInstanceState -> RESPONSE_CREATE_202_ACCEPTED);
+	}
+
+	private Mono<UpdateServiceInstanceResponse> emitUpdateAcceptedOnConcurrentRequest(UpdateServiceInstanceRequest request) {
+		return getCurrentServiceInstanceState(request.getServiceInstanceId())
+			.filter(serviceInstanceState -> OperationState.IN_PROGRESS.equals(serviceInstanceState.getOperationState()))
+			.doOnNext(serviceInstanceState -> {
+				//A provisionning is in progress with the same Id, return 202 Accepted status code
+				//There is a small accepted risk that the operation is not a create, but a update/delete service
+				// instance
+				log.info("Assuming duplicate update request with id={} as one operation is inflight with " +
+						"message={}, " +
+						"returning 202 accepted without " +
+						"triggering a new provisionning workflow", serviceInstanceState.getDescription(),
+					request.getServiceInstanceId());
+			})
+			.map(serviceInstanceState -> RESPONSE_UPDATE_202_ACCEPTED);
+	}
+
+	private Mono<ServiceInstanceState> getCurrentServiceInstanceState(String serviceInstanceId) {
+		return stateRepository.getState(serviceInstanceId)
+				.doOnError(details ->
+					log.debug("Current state for {} returned error {}",
+						serviceInstanceId,
+						details.toString()))
+				.onErrorResume(t -> {
+					if (t instanceof IllegalArgumentException && t.toString().contains("Unknown service instance ID")) {
+						return Mono.empty();
+					}
+					else {
+						//Do rethrow other exception such as inability to access the state repository.
+						throw new RuntimeException(t);
+					}
+				});
 	}
 
 	private Mono<CreateServiceInstanceResponse> invokeCreateResponseBuilders(CreateServiceInstanceRequest request) {
@@ -95,14 +163,13 @@ public class WorkflowServiceInstanceService implements ServiceInstanceService {
 	}
 
 	private Mono<Void> create(CreateServiceInstanceRequest request, CreateServiceInstanceResponse response) {
-		return stateRepository.saveState(request.getServiceInstanceId(),
-			OperationState.IN_PROGRESS,
-			"create service instance started")
+		return Mono.empty()
+			.publishOn(Schedulers.parallel())
 			.thenMany(invokeCreateWorkflows(request, response)
 				.doOnRequest(l -> log.debug("Creating service instance"))
 				.doOnComplete(() -> log.debug("Finished creating service instance"))
 				.doOnError(exception -> log.error(String.format("Error creating service instance with error '%s'",
-					exception.getMessage()), exception)))
+						exception.getMessage()), exception)))
 			.thenEmpty(stateRepository.saveState(request.getServiceInstanceId(),
 				OperationState.SUCCEEDED, "create service instance completed")
 				.then())
@@ -120,10 +187,30 @@ public class WorkflowServiceInstanceService implements ServiceInstanceService {
 
 	@Override
 	public Mono<DeleteServiceInstanceResponse> deleteServiceInstance(DeleteServiceInstanceRequest request) {
-		return invokeDeleteResponseBuilders(request)
-			.publishOn(Schedulers.parallel())
-			.doOnNext(response -> delete(request, response)
-				.subscribe());
+		return
+			emitDeleteAcceptedOnConcurrentRequest(request)
+			.switchIfEmpty(
+				stateRepository.saveState(request.getServiceInstanceId(),
+					OperationState.IN_PROGRESS,
+					"delete service instance started")
+				.then(
+					invokeDeleteResponseBuilders(request)
+						.doOnNext(response -> delete(request, response).subscribe())));
+	}
+
+	private Mono<DeleteServiceInstanceResponse> emitDeleteAcceptedOnConcurrentRequest(
+		DeleteServiceInstanceRequest request) {
+		return getCurrentServiceInstanceState(request.getServiceInstanceId())
+			.filter(serviceInstanceState -> OperationState.IN_PROGRESS.equals(serviceInstanceState.getOperationState()))
+			.doOnNext(serviceInstanceState -> {
+				//A deprovisionning is in progress with the same Id, return 202 Accepted status code
+				log.info("Assuming duplicate deprovisioning request with id={} as one operation is inflight with " +
+						"message={}, " +
+						"returning 202 accepted without " +
+						"triggering a new deprovisionning workflow", serviceInstanceState.getDescription(),
+					request.getServiceInstanceId());
+			})
+			.map(serviceInstanceState -> RESPONSE_DELETE_202_ACCEPTED);
 	}
 
 	private Mono<DeleteServiceInstanceResponse> invokeDeleteResponseBuilders(DeleteServiceInstanceRequest request) {
@@ -139,8 +226,8 @@ public class WorkflowServiceInstanceService implements ServiceInstanceService {
 	}
 
 	private Mono<Void> delete(DeleteServiceInstanceRequest request, DeleteServiceInstanceResponse response) {
-		return stateRepository.saveState(request.getServiceInstanceId(),
-			OperationState.IN_PROGRESS, "delete service instance started")
+		return Mono.empty()
+			.publishOn(Schedulers.parallel())
 			.thenMany(invokeDeleteWorkflows(request, response)
 				.doOnRequest(l -> log.debug("Deleting service instance"))
 				.doOnComplete(() -> log.debug("Finished deleting service instance"))
@@ -163,10 +250,17 @@ public class WorkflowServiceInstanceService implements ServiceInstanceService {
 
 	@Override
 	public Mono<UpdateServiceInstanceResponse> updateServiceInstance(UpdateServiceInstanceRequest request) {
-		return invokeUpdateResponseBuilders(request)
-			.publishOn(Schedulers.parallel())
+		return
+			emitUpdateAcceptedOnConcurrentRequest(request)
+				.switchIfEmpty(
+					stateRepository.saveState(request.getServiceInstanceId(),
+						OperationState.IN_PROGRESS,
+						"update service instance started")
+						.then(
+
+							invokeUpdateResponseBuilders(request)
 			.doOnNext(response -> update(request, response)
-				.subscribe());
+				.subscribe())));
 	}
 
 	private Mono<UpdateServiceInstanceResponse> invokeUpdateResponseBuilders(UpdateServiceInstanceRequest request) {
@@ -182,8 +276,9 @@ public class WorkflowServiceInstanceService implements ServiceInstanceService {
 	}
 
 	private Mono<Void> update(UpdateServiceInstanceRequest request, UpdateServiceInstanceResponse response) {
-		return stateRepository.saveState(request.getServiceInstanceId(),
-			OperationState.IN_PROGRESS, "update service instance started")
+		return
+			Mono.empty()
+			.publishOn(Schedulers.parallel())
 			.thenMany(invokeUpdateWorkflows(request, response)
 				.doOnRequest(l -> log.debug("Updating service instance"))
 				.doOnComplete(() -> log.debug("Finished updating service instance"))

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/service/WorkflowServiceInstanceServiceTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/service/WorkflowServiceInstanceServiceTest.java
@@ -527,6 +527,12 @@ class WorkflowServiceInstanceServiceTest {
 
 	@Test
 	void deleteServiceInstanceWithResponseError() {
+		when(serviceInstanceStateRepository.getState(anyString()))
+			.thenReturn(Mono.error(new IllegalArgumentException("Unknown service instance ID ")));
+		when(serviceInstanceStateRepository.saveState(anyString(), any(OperationState.class), anyString()))
+			.thenReturn(Mono.just(new ServiceInstanceState(OperationState.IN_PROGRESS, "delete service instance started",
+				new Timestamp(Instant.now().minusSeconds(60).toEpochMilli()))));
+
 		DeleteServiceInstanceRequest request = DeleteServiceInstanceRequest.builder()
 				.serviceInstanceId("foo")
 				.build();


### PR DESCRIPTION
This is a WIP that cherry picks https://github.com/orange-cloudfoundry/osb-cmdb-spike/pull/27 and starts addressing #337, see related design notes at https://github.com/orange-cloudfoundry/osb-cmdb-spike/issues/17#issuecomment-589705368

Compiles, but there are still some test failures. Need to further diagnose whether this is regression introduced in production code during cherry pick or test that need update. I submitted this PR in case this might help as inspiration, but this is not yet finished.

I'm not sure to be able to allocate much more time on this PR in the short term, so feel free to close this PR if this feels more like pollution.

-----------------

Dupl provisioning, update and unprovisionning request support:
- Modified service instance repository to be checked and saved for "in progress" status on the servlet thread, as to avoid race condition with the reactor thread
- Only skip duplicate request when state repository has an inprogress request, and still fail on async CF-ServiceInstanceNameTaken(60002) for now
- Include log to help diagnose ignored duplicate API calls
- WorkflowServiceInstanceServiceTest completed with a test when a provisionning is in progress
