### PR TITLE
Document use of intellij codestyle to format import

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -23,13 +23,8 @@ unacceptable behavior to spring-code-of-conduct@pivotal.io.
 None of these is essential for a pull request, but they will all help.  They can also be
 added after the original pull request but before a merge.
 
-* Use the Spring Framework code format conventions. If you use Eclipse
-  you can import formatter settings using the
-  `eclipse-code-formatter.xml` file from the
-  https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
-  Cloud Build] project. If using IntelliJ, you can use the
-  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
-  Plugin] to import the same file.
+* Use the Spring Cloud App Broker format conventions documented in  `src/idea/idea.xml`. If using IntelliJ, you can use import this code style through the `Editor > code style > import -> intellij idea format` settings.
+* Make sure to optimize imports (e.g. in IntelliJ `Code -> Optimize Imports` or automatically through the `Optimize Imports` checkbox in the commit dialog )
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
   for.


### PR DESCRIPTION
Document use of intellij codestyle to format import as expected by gradle build

Relates to #346 although more changes might be required such as the followings which do not seem to be currently in sync with project code or PR reviews

> Make sure all new .java files to have a simple Javadoc class comment with at least an @author tag identifying you, and preferably at least a paragraph on what the class is for.

