### PR TITLE
Routes property overrides conflicting app manifest properties

### DIFF
--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryDeploymentProperties.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryDeploymentProperties.java
@@ -61,11 +61,6 @@ public class CloudFoundryDeploymentProperties extends DeploymentProperties {
 	protected static final String ROUTE_PATH_PROPERTY = "route-path";
 
 	/**
-	 * Key for storing the route deployment property
-	 */
-	protected static final String ROUTE_PROPERTY = "route";
-
-	/**
 	 * Key for storing the routes deployment property
 	 */
 	protected static final String ROUTES_PROPERTY = "routes";


### PR DESCRIPTION
Currently App Broker allows users to specify mutually exclusive
manifest properties - specifically `routes` along with any combination
of the deprecated `host`, `hosts`, `domain` and `domains`. This change
makes `routes` take precedence if specified.