### PR TITLE
Run sync binding / unbinding operations synchronously

### DIFF
--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/service/WorkflowServiceInstanceBindingService.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/service/WorkflowServiceInstanceBindingService.java
@@ -81,9 +81,18 @@ public class WorkflowServiceInstanceBindingService implements ServiceInstanceBin
 	public Mono<CreateServiceInstanceBindingResponse> createServiceInstanceBinding(
 		CreateServiceInstanceBindingRequest request) {
 		return invokeCreateResponseBuilders(request)
-			.publishOn(Schedulers.parallel())
-			.doOnNext(response -> create(request, response)
-				.subscribe());
+			.flatMap(response -> {
+				if (response.isAsync()) {
+					return Mono.just(response)
+						.publishOn(Schedulers.parallel())
+						.doOnNext(r -> create(request, r)
+							.subscribe());
+				}
+				else {
+					return invokeCreateWorkflows(request, response)
+						.then(Mono.just(response));
+				}
+			});
 	}
 
 	private Mono<CreateServiceInstanceBindingResponse> invokeCreateResponseBuilders(
@@ -144,11 +153,7 @@ public class WorkflowServiceInstanceBindingService implements ServiceInstanceBin
 		CreateServiceInstanceBindingResponse response) {
 		return stateRepository.saveState(request.getServiceInstanceId(), request.getBindingId(),
 			OperationState.IN_PROGRESS, "create service instance binding started")
-			.thenMany(invokeCreateWorkflows(request, response)
-				.doOnRequest(l -> LOG.debug("Creating service instance binding"))
-				.doOnComplete(() -> LOG.debug("Finished creating service instance binding"))
-				.doOnError(exception -> LOG.error(String.format("Error creating service instance binding with error " +
-					"'%s'", exception.getMessage()), exception)))
+			.thenMany(invokeCreateWorkflows(request, response))
 			.thenEmpty(stateRepository.saveState(request.getServiceInstanceId(), request.getBindingId(),
 				OperationState.SUCCEEDED, "create service instance binding completed")
 				.then())
@@ -174,16 +179,28 @@ public class WorkflowServiceInstanceBindingService implements ServiceInstanceBin
 						(CreateServiceInstanceRouteBindingResponse) response));
 			}
 			return Flux.empty();
-		});
+		})
+			.doOnRequest(l -> LOG.debug("Creating service instance binding"))
+			.doOnComplete(() -> LOG.debug("Finished creating service instance binding"))
+			.doOnError(exception -> LOG.error(String.format("Error creating service instance binding with error " +
+				"'%s'", exception.getMessage()), exception));
 	}
 
 	@Override
 	public Mono<DeleteServiceInstanceBindingResponse> deleteServiceInstanceBinding(
 		DeleteServiceInstanceBindingRequest request) {
 		return invokeDeleteResponseBuilders(request)
-			.publishOn(Schedulers.parallel())
-			.doOnNext(response -> delete(request, response)
-				.subscribe());
+			.flatMap(response -> {
+				if (response.isAsync()) {
+					return Mono.just(response)
+						.publishOn(Schedulers.parallel())
+						.doOnNext(r -> delete(request, r)
+							.subscribe());
+				}
+				else {
+					return invokeDeleteWorkflows(request, response).then(Mono.just(response));
+				}
+			});
 	}
 
 	private Mono<DeleteServiceInstanceBindingResponse> invokeDeleteResponseBuilders(
@@ -203,11 +220,7 @@ public class WorkflowServiceInstanceBindingService implements ServiceInstanceBin
 		DeleteServiceInstanceBindingResponse response) {
 		return stateRepository.saveState(request.getServiceInstanceId(), request.getBindingId(),
 			OperationState.IN_PROGRESS, "delete service instance binding started")
-			.thenMany(invokeDeleteWorkflows(request, response)
-				.doOnRequest(l -> LOG.debug("Deleting service instance binding"))
-				.doOnComplete(() -> LOG.debug("Finished deleting service instance binding"))
-				.doOnError(exception -> LOG.error(String.format("Error deleting service instance binding with error " +
-					"'%s'", exception.getMessage()), exception)))
+			.thenMany(invokeDeleteWorkflows(request, response))
 			.thenEmpty(stateRepository.saveState(request.getServiceInstanceId(), request.getBindingId(),
 				OperationState.SUCCEEDED, "delete service instance binding completed")
 				.then())
@@ -221,7 +234,11 @@ public class WorkflowServiceInstanceBindingService implements ServiceInstanceBin
 		DeleteServiceInstanceBindingResponse response) {
 		return Flux.fromIterable(deleteServiceInstanceBindingWorkflows)
 			.filterWhen(workflow -> workflow.accept(request))
-			.concatMap(workflow -> workflow.delete(request, response));
+			.concatMap(workflow -> workflow.delete(request, response))
+			.doOnRequest(l -> LOG.debug("Deleting service instance binding"))
+			.doOnComplete(() -> LOG.debug("Finished deleting service instance binding"))
+			.doOnError(exception -> LOG.error(String.format("Error deleting service instance binding with error " +
+				"'%s'", exception.getMessage()), exception));
 	}
 
 	@Override


### PR DESCRIPTION
Unlike provisioning / deprovisioning, binding can be a fully synchronous
operation, i.e. it should fully complete within a request lifecycle.
There is no need to update service instance state or run create / delete
workflows in a parallel scheduler.

The existing flow should still be enabled for async binding.