### PR TITLE
Fix an issue where configured backing services are not being deleted

### DIFF
--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/BackingService.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/BackingService.java
@@ -120,6 +120,14 @@ public class BackingService {
 		this.rebindOnUpdate = rebindOnUpdate;
 	}
 
+	public int serviceInstanceNameAndSpaceHashCode() {
+		String space = null;
+		if (!CollectionUtils.isEmpty(properties)) {
+			space = properties.get(DeploymentProperties.TARGET_PROPERTY_KEY);
+		}
+		return Objects.hash(serviceInstanceName, space);
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentCreateServiceInstanceWorkflow.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentCreateServiceInstanceWorkflow.java
@@ -78,10 +78,10 @@ public class AppDeploymentCreateServiceInstanceWorkflow
 
 	private Flux<String> createBackingServices(CreateServiceInstanceRequest request) {
 		return getBackingServicesForService(request.getServiceDefinition(), request.getPlan())
-			.flatMap(backingServices ->
-				targetService.addToBackingServices(backingServices,
-					getTargetForService(request.getServiceDefinition(), request.getPlan()),
+			.flatMap(backingServices -> getTargetForService(request.getServiceDefinition(), request.getPlan())
+				.flatMap(targetSpec -> targetService.addToBackingServices(backingServices, targetSpec,
 					request.getServiceInstanceId()))
+				.defaultIfEmpty(backingServices))
 			.flatMap(backingServices ->
 				servicesParametersTransformationService.transformParameters(backingServices,
 					request.getParameters()))
@@ -97,10 +97,10 @@ public class AppDeploymentCreateServiceInstanceWorkflow
 
 	private Flux<String> deployBackingApplications(CreateServiceInstanceRequest request) {
 		return getBackingApplicationsForService(request.getServiceDefinition(), request.getPlan())
-			.flatMap(backingApps ->
-				targetService.addToBackingApplications(backingApps,
-					getTargetForService(request.getServiceDefinition(),
-						request.getPlan()), request.getServiceInstanceId()))
+			.flatMap(backingApps -> getTargetForService(request.getServiceDefinition(), request.getPlan())
+				.flatMap(targetSpec -> targetService.addToBackingApplications(backingApps, targetSpec,
+					request.getServiceInstanceId()))
+				.defaultIfEmpty(backingApps))
 			.flatMap(backingApps ->
 				appsParametersTransformationService.transformParameters(backingApps,
 					request.getParameters()))

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentUpdateServiceInstanceWorkflow.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentUpdateServiceInstanceWorkflow.java
@@ -87,10 +87,10 @@ public class AppDeploymentUpdateServiceInstanceWorkflow extends AppDeploymentIns
 
 	private Flux<String> updateBackingServices(UpdateServiceInstanceRequest request) {
 		return getBackingServicesForService(request.getServiceDefinition(), request.getPlan())
-			.flatMap(backingServices ->
-				targetService.addToBackingServices(backingServices,
-					getTargetForService(request.getServiceDefinition(), request.getPlan()),
+			.flatMap(backingServices -> getTargetForService(request.getServiceDefinition(), request.getPlan())
+				.flatMap(targetSpec -> targetService.addToBackingServices(backingServices, targetSpec,
 					request.getServiceInstanceId()))
+				.defaultIfEmpty(backingServices))
 			.flatMap(backingServices ->
 				servicesParametersTransformationService.transformParameters(backingServices,
 					request.getParameters()))
@@ -163,10 +163,10 @@ public class AppDeploymentUpdateServiceInstanceWorkflow extends AppDeploymentIns
 
 	private Flux<String> updateBackingApplications(UpdateServiceInstanceRequest request) {
 		return getBackingApplicationsForService(request.getServiceDefinition(), request.getPlan())
-			.flatMap(backingApps ->
-				targetService.addToBackingApplications(backingApps,
-					getTargetForService(request.getServiceDefinition(), request.getPlan()),
+			.flatMap(backingApps -> getTargetForService(request.getServiceDefinition(), request.getPlan())
+				.flatMap(targetSpec -> targetService.addToBackingApplications(backingApps, targetSpec,
 					request.getServiceInstanceId()))
+				.defaultIfEmpty(backingApps))
 			.flatMap(backingApps ->
 				appsParametersTransformationService.transformParameters(backingApps, request.getParameters()))
 			.flatMapMany(backingApps -> deploymentService.update(backingApps, request.getServiceInstanceId()))

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentDeleteServiceInstanceWorkflowTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentDeleteServiceInstanceWorkflowTest.java
@@ -234,8 +234,6 @@ class AppDeploymentDeleteServiceInstanceWorkflowTest {
 		// no backing apps
 		given(this.backingAppManagementService.getDeployedBackingApplications(eq(request.getServiceInstanceId())))
 			.willReturn(Mono.empty());
-		given(this.credentialProviderService.deleteCredentials(any(), eq(request.getServiceInstanceId())))
-			.willReturn(Mono.empty());
 
 		given(this.backingServicesProvisionService.deleteServiceInstance(argThat(backingServices -> {
 			boolean nameMatch = "my-service-instance".equals(backingServices.get(0).getServiceInstanceName());

--- a/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/fixtures/CloudControllerStubFixture.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/fixtures/CloudControllerStubFixture.java
@@ -492,6 +492,14 @@ public class CloudControllerStubFixture extends WiremockStubFixture {
 		stubGetServiceAndGetPlan(serviceName, planName);
 	}
 
+	public void stubServiceBindingsDoNotExist(String serviceInstanceName) {
+		stubFor(get(urlPathEqualTo("/v2/service_bindings"))
+			.withQueryParam("q", equalTo("service_instance_guid:" + serviceInstanceGuid(serviceInstanceName)))
+			.withQueryParam("page", equalTo("1"))
+			.willReturn(ok()
+				.withBody(cc("empty-query-results"))));
+	}
+
 	public void stubGetBackingServiceInstance(String serviceInstanceName, String serviceName, String planName) {
 		String serviceInstanceId = serviceInstanceGuid(serviceInstanceName);
 		stubServiceInstanceExists(serviceInstanceId, serviceInstanceName, serviceName, planName);


### PR DESCRIPTION
When a service instance is deleted, all configured backing services will
be deleted as well as all services bound to any backing applications

Resolve #344