### PR TITLE
Remove CAPI call to get service name and plan

### DIFF
--- a/spring-cloud-app-broker-acceptance-tests/src/main/java/org/springframework/cloud/appbroker/acceptance/ManagementController.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/main/java/org/springframework/cloud/appbroker/acceptance/ManagementController.java
@@ -46,9 +46,13 @@ public class ManagementController {
 	 * @param serviceInstanceId the id of the service to test
 	 * @return a response
 	 */
-	@GetMapping("/start/{serviceInstanceId}")
-	public Mono<String> startApplications(@PathVariable String serviceInstanceId) {
-		return service.start(serviceInstanceId)
+	@GetMapping("/start/{serviceName}/{planName}/{serviceInstanceId}")
+	public Mono<String> startApplications(
+		@PathVariable String serviceInstanceId,
+		@PathVariable String serviceName,
+		@PathVariable String planName
+	) {
+		return service.start(serviceInstanceId, serviceName, planName)
 			.thenReturn("starting " + serviceInstanceId);
 	}
 
@@ -58,9 +62,13 @@ public class ManagementController {
 	 * @param serviceInstanceId the id of the service to test
 	 * @return a response
 	 */
-	@GetMapping("/stop/{serviceInstanceId}")
-	public Mono<String> stopApplications(@PathVariable String serviceInstanceId) {
-		return service.stop(serviceInstanceId)
+	@GetMapping("/stop/{serviceName}/{planName}/{serviceInstanceId}")
+	public Mono<String> stopApplications(
+		@PathVariable String serviceInstanceId,
+		@PathVariable String serviceName,
+		@PathVariable String planName
+	) {
+		return service.stop(serviceInstanceId, serviceName, planName)
 			.thenReturn("stopping " + serviceInstanceId);
 	}
 
@@ -70,9 +78,13 @@ public class ManagementController {
 	 * @param serviceInstanceId the id of the service to test
 	 * @return a response
 	 */
-	@GetMapping("/restart/{serviceInstanceId}")
-	public Mono<String> restartApplications(@PathVariable String serviceInstanceId) {
-		return service.restart(serviceInstanceId)
+	@GetMapping("/restart/{serviceName}/{planName}/{serviceInstanceId}")
+	public Mono<String> restartApplications(
+		@PathVariable String serviceInstanceId,
+		@PathVariable String serviceName,
+		@PathVariable String planName
+	) {
+		return service.restart(serviceInstanceId, serviceName, planName)
 			.thenReturn("restarting " + serviceInstanceId);
 	}
 
@@ -82,9 +94,13 @@ public class ManagementController {
 	 * @param serviceInstanceId the id of the service to test
 	 * @return a response
 	 */
-	@GetMapping("/restage/{serviceInstanceId}")
-	public Mono<String> restageApplications(@PathVariable String serviceInstanceId) {
-		return service.restage(serviceInstanceId)
+	@GetMapping("/restage/{serviceName}/{planName}/{serviceInstanceId}")
+	public Mono<String> restageApplications(
+		@PathVariable String serviceInstanceId,
+		@PathVariable String serviceName,
+		@PathVariable String planName
+	) {
+		return service.restage(serviceInstanceId, serviceName, planName)
 			.thenReturn("restaging " + serviceInstanceId);
 	}
 

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/AppManagementRestageAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/AppManagementRestageAcceptanceTest.java
@@ -58,20 +58,20 @@ class AppManagementRestageAcceptanceTest extends CloudFoundryAcceptanceTest {
 
 	@BeforeEach
 	void setUp() {
-		StepVerifier.create(cloudFoundryService.deleteServiceInstance(SI_NAME))
+		StepVerifier.create(userCloudFoundryService.deleteServiceInstance(SI_NAME))
 			.verifyComplete();
 
-		StepVerifier.create(cloudFoundryService.createServiceInstance(PLAN_NAME, APP_SERVICE_NAME, SI_NAME, null))
+		StepVerifier.create(userCloudFoundryService.createServiceInstance(PLAN_NAME, APP_SERVICE_NAME, SI_NAME, null))
 			.verifyComplete();
 
-		StepVerifier.create(cloudFoundryService.getServiceInstance(SI_NAME))
+		StepVerifier.create(userCloudFoundryService.getServiceInstance(SI_NAME))
 			.assertNext(serviceInstance -> assertThat(serviceInstance.getStatus()).isEqualTo("succeeded"))
 			.verifyComplete();
 	}
 
 	@AfterEach
 	void cleanUp() {
-		StepVerifier.create(cloudFoundryService.deleteServiceInstance(SI_NAME))
+		StepVerifier.create(userCloudFoundryService.deleteServiceInstance(SI_NAME))
 			.verifyComplete();
 
 		StepVerifier.create(getApplications(APP_1, APP_2))
@@ -93,7 +93,7 @@ class AppManagementRestageAcceptanceTest extends CloudFoundryAcceptanceTest {
 		Date originallySince2 = apps.get(1).getInstanceDetails().get(0).getSince();
 		assertThat(apps).extracting("runningInstances").containsOnly(1);
 
-		StepVerifier.create(manageApps(SI_NAME, "restage"))
+		StepVerifier.create(manageApps(SI_NAME, APP_SERVICE_NAME, PLAN_NAME, "restage"))
 			.assertNext(result -> assertThat(result).contains("restaging"))
 			.verifyComplete();
 

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/AppManagementRestartAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/AppManagementRestartAcceptanceTest.java
@@ -33,7 +33,7 @@ class AppManagementRestartAcceptanceTest extends CloudFoundryAcceptanceTest {
 
 	private static final String APP_1 = "app-1-" + SUFFIX;
 
-	private static final String APP_2 = "app-2" + SUFFIX;
+	private static final String APP_2 = "app-2-" + SUFFIX;
 
 	private static final String SI_NAME = "si-managed" + SUFFIX;
 
@@ -58,20 +58,20 @@ class AppManagementRestartAcceptanceTest extends CloudFoundryAcceptanceTest {
 
 	@BeforeEach
 	void setUp() {
-		StepVerifier.create(cloudFoundryService.deleteServiceInstance(SI_NAME))
+		StepVerifier.create(userCloudFoundryService.deleteServiceInstance(SI_NAME))
 			.verifyComplete();
 
-		StepVerifier.create(cloudFoundryService.createServiceInstance(PLAN_NAME, APP_SERVICE_NAME, SI_NAME, null))
+		StepVerifier.create(userCloudFoundryService.createServiceInstance(PLAN_NAME, APP_SERVICE_NAME, SI_NAME, null))
 			.verifyComplete();
 
-		StepVerifier.create(cloudFoundryService.getServiceInstance(SI_NAME))
+		StepVerifier.create(userCloudFoundryService.getServiceInstance(SI_NAME))
 			.assertNext(serviceInstance -> assertThat(serviceInstance.getStatus()).isEqualTo("succeeded"))
 			.verifyComplete();
 	}
 
 	@AfterEach
 	void cleanUp() {
-		StepVerifier.create(cloudFoundryService.deleteServiceInstance(SI_NAME))
+		StepVerifier.create(userCloudFoundryService.deleteServiceInstance(SI_NAME))
 			.verifyComplete();
 
 		StepVerifier.create(getApplications(APP_1, APP_2))
@@ -92,7 +92,7 @@ class AppManagementRestartAcceptanceTest extends CloudFoundryAcceptanceTest {
 		Date originallySince1 = apps.get(0).getInstanceDetails().get(0).getSince();
 		Date originallySince2 = apps.get(1).getInstanceDetails().get(0).getSince();
 
-		StepVerifier.create(manageApps(SI_NAME, "restart"))
+		StepVerifier.create(manageApps(SI_NAME, APP_SERVICE_NAME, PLAN_NAME, "restart"))
 			.assertNext(result -> assertThat(result).contains("restarting"))
 			.verifyComplete();
 

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/AppManagementStartAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/AppManagementStartAcceptanceTest.java
@@ -54,20 +54,20 @@ class AppManagementStartAcceptanceTest extends CloudFoundryAcceptanceTest {
 
 	@BeforeEach
 	void setUp() {
-		StepVerifier.create(cloudFoundryService.deleteServiceInstance(SI_NAME))
+		StepVerifier.create(userCloudFoundryService.deleteServiceInstance(SI_NAME))
 			.verifyComplete();
 
-		StepVerifier.create(cloudFoundryService.createServiceInstance(PLAN_NAME, APP_SERVICE_NAME, SI_NAME, null))
+		StepVerifier.create(userCloudFoundryService.createServiceInstance(PLAN_NAME, APP_SERVICE_NAME, SI_NAME, null))
 			.verifyComplete();
 
-		StepVerifier.create(cloudFoundryService.getServiceInstance(SI_NAME))
+		StepVerifier.create(userCloudFoundryService.getServiceInstance(SI_NAME))
 			.assertNext(serviceInstance -> assertThat(serviceInstance.getStatus()).isEqualTo("succeeded"))
 			.verifyComplete();
 	}
 
 	@AfterEach
 	void cleanUp() {
-		StepVerifier.create(cloudFoundryService.deleteServiceInstance(SI_NAME))
+		StepVerifier.create(userCloudFoundryService.deleteServiceInstance(SI_NAME))
 			.verifyComplete();
 
 		StepVerifier.create(getApplications(APP_1, APP_2))
@@ -92,7 +92,7 @@ class AppManagementStartAcceptanceTest extends CloudFoundryAcceptanceTest {
 			.assertNext(apps -> assertThat(apps).extracting("runningInstances").containsOnly(0))
 			.verifyComplete();
 
-		StepVerifier.create(manageApps(SI_NAME, "start"))
+		StepVerifier.create(manageApps(SI_NAME, APP_SERVICE_NAME, PLAN_NAME, "start"))
 			.assertNext(result -> assertThat(result).contains("starting"))
 			.verifyComplete();
 

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/AppManagementStopAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/AppManagementStopAcceptanceTest.java
@@ -54,20 +54,20 @@ class AppManagementStopAcceptanceTest extends CloudFoundryAcceptanceTest {
 
 	@BeforeEach
 	void setUp() {
-		StepVerifier.create(cloudFoundryService.deleteServiceInstance(SI_NAME))
+		StepVerifier.create(userCloudFoundryService.deleteServiceInstance(SI_NAME))
 			.verifyComplete();
 
-		StepVerifier.create(cloudFoundryService.createServiceInstance(PLAN_NAME, APP_SERVICE_NAME, SI_NAME, null))
+		StepVerifier.create(userCloudFoundryService.createServiceInstance(PLAN_NAME, APP_SERVICE_NAME, SI_NAME, null))
 			.verifyComplete();
 
-		StepVerifier.create(cloudFoundryService.getServiceInstance(SI_NAME))
+		StepVerifier.create(userCloudFoundryService.getServiceInstance(SI_NAME))
 			.assertNext(serviceInstance -> assertThat(serviceInstance.getStatus()).isEqualTo("succeeded"))
 			.verifyComplete();
 	}
 
 	@AfterEach
 	void cleanUp() {
-		StepVerifier.create(cloudFoundryService.deleteServiceInstance(SI_NAME))
+		StepVerifier.create(userCloudFoundryService.deleteServiceInstance(SI_NAME))
 			.verifyComplete();
 
 		StepVerifier.create(getApplications(APP_1, APP_2))
@@ -84,7 +84,7 @@ class AppManagementStopAcceptanceTest extends CloudFoundryAcceptanceTest {
 		"spring.cloud.appbroker.services[0].apps[1].path=" + BACKING_APP_PATH
 	})
 	void stopApps() {
-		StepVerifier.create(manageApps(SI_NAME, "stop"))
+		StepVerifier.create(manageApps(SI_NAME, APP_SERVICE_NAME, PLAN_NAME, "stop"))
 			.assertNext(result -> assertThat(result).contains("stopping"))
 			.verifyComplete();
 

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/CreateInstanceWithServiceInstanceGuidSuffixTargetAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/CreateInstanceWithServiceInstanceGuidSuffixTargetAcceptanceTest.java
@@ -83,7 +83,7 @@ class CreateInstanceWithServiceInstanceGuidSuffixTargetAcceptanceTest extends Cl
 
 		// and the services are bound to it
 		final String expectedServiceInstanceName = BACKING_SI_NAME + "-" + serviceInstanceGuid;
-		ServiceInstance serviceInstance1 = getServiceInstance(expectedServiceInstanceName);
+		ServiceInstance serviceInstance1 = getBackingServiceInstance(expectedServiceInstanceName);
 		assertThat(serviceInstance1.getApplications()).contains(expectedApplicationName);
 
 		// when the service instance is deleted

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/CreateInstanceWithServicesAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/CreateInstanceWithServicesAcceptanceTest.java
@@ -70,7 +70,7 @@ class CreateInstanceWithServicesAcceptanceTest extends CloudFoundryAcceptanceTes
 	})
 	void deployAppsAndCreateServicesOnCreateService() {
 		// given that a service is available in the marketplace
-		createServiceInstance(BACKING_SERVICE_NAME, PLAN_NAME, BACKING_SI_2_NAME, emptyMap());
+		createBackingServiceInstance(BACKING_SERVICE_NAME, PLAN_NAME, BACKING_SI_2_NAME, emptyMap());
 
 		// when a service instance is created
 		createServiceInstance(SI_NAME);
@@ -81,10 +81,10 @@ class CreateInstanceWithServicesAcceptanceTest extends CloudFoundryAcceptanceTes
 			assertThat(app.getRunningInstances()).isEqualTo(1));
 
 		// and the services are bound to it
-		ServiceInstance serviceInstance1 = getServiceInstance(BACKING_SI_1_NAME);
+		ServiceInstance serviceInstance1 = getBackingServiceInstance(BACKING_SI_1_NAME);
 		assertThat(serviceInstance1.getApplications()).contains(APP_NAME);
 
-		ServiceInstance serviceInstance2 = getServiceInstance(BACKING_SI_2_NAME);
+		ServiceInstance serviceInstance2 = getBackingServiceInstance(BACKING_SI_2_NAME);
 		assertThat(serviceInstance2.getApplications()).contains(APP_NAME);
 
 		// when the service instance is deleted

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/CreateInstanceWithSpacePerServiceInstanceTargetAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/CreateInstanceWithSpacePerServiceInstanceTargetAcceptanceTest.java
@@ -95,7 +95,7 @@ class CreateInstanceWithSpacePerServiceInstanceTargetAcceptanceTest extends Clou
 			assertThat(app.getRunningInstances()).isEqualTo(1));
 
 		// and the services are bound to it
-		ServiceInstance serviceInstance1 = getServiceInstance(BACKING_SI_NAME, spaceName);
+		ServiceInstance serviceInstance1 = getBackingServiceInstance(BACKING_SI_NAME, spaceName);
 		assertThat(serviceInstance1.getApplications()).contains(APP_NAME_1);
 
 		// when the service instance is deleted

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/UpdateInstanceWithNewServiceAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/UpdateInstanceWithNewServiceAcceptanceTest.java
@@ -99,7 +99,7 @@ class UpdateInstanceWithNewServiceAcceptanceTest extends CloudFoundryAcceptanceT
 			assertThat(app.getRunningInstances()).isEqualTo(1));
 
 		// and the services are bound to it
-		ServiceInstance backingServiceInstance = getServiceInstance(OLD_BACKING_SI_NAME);
+		ServiceInstance backingServiceInstance = getBackingServiceInstance(OLD_BACKING_SI_NAME);
 		assertThat(backingServiceInstance.getApplications()).contains(APP_NAME);
 
 		String path = backingApplication.get().getUrls().get(0);
@@ -136,7 +136,7 @@ class UpdateInstanceWithNewServiceAcceptanceTest extends CloudFoundryAcceptanceT
 			assertThat(app.getRunningInstances()).isEqualTo(1));
 
 		// and the new backing service is bound to it
-		ServiceInstance newBackingServiceInstance = getServiceInstance(NEW_BACKING_SI_NAME);
+		ServiceInstance newBackingServiceInstance = getBackingServiceInstance(NEW_BACKING_SI_NAME);
 		assertThat(newBackingServiceInstance.getApplications()).contains(APP_NAME);
 
 		// and the old backing service is deleted

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/UpdateInstanceWithServicesAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/UpdateInstanceWithServicesAcceptanceTest.java
@@ -84,7 +84,7 @@ class UpdateInstanceWithServicesAcceptanceTest extends CloudFoundryAcceptanceTes
 			assertThat(app.getRunningInstances()).isEqualTo(1));
 
 		// and the services are bound to it
-		ServiceInstance backingServiceInstance = getServiceInstance(BACKING_SI_NAME);
+		ServiceInstance backingServiceInstance = getBackingServiceInstance(BACKING_SI_NAME);
 		assertThat(backingServiceInstance.getApplications()).contains(APP_NAME);
 
 		String path = backingApplication.get().getUrls().get(0);
@@ -108,7 +108,7 @@ class UpdateInstanceWithServicesAcceptanceTest extends CloudFoundryAcceptanceTes
 			assertThat(app.getRunningInstances()).isEqualTo(1));
 
 		// and the services are still bound to it
-		ServiceInstance backingServiceInstanceUpdated = getServiceInstance(BACKING_SI_NAME);
+		ServiceInstance backingServiceInstanceUpdated = getBackingServiceInstance(BACKING_SI_NAME);
 		assertThat(backingServiceInstanceUpdated.getApplications()).contains(APP_NAME);
 
 		// then the service instance is deleted

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/fixtures/cf/CloudFoundryClientConfiguration.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/fixtures/cf/CloudFoundryClientConfiguration.java
@@ -43,15 +43,32 @@ import org.springframework.context.annotation.Configuration;
 public class CloudFoundryClientConfiguration {
 
 	/**
-	 * The client secret
+	 * The broker client secret
 	 */
 	public static final String APP_BROKER_CLIENT_SECRET = "app-broker-client-secret";
 
 	/**
-	 * The client authorities
+	 * The broker client authorities
 	 */
 	public static final String[] APP_BROKER_CLIENT_AUTHORITIES = {
 		"cloud_controller.read", "cloud_controller.write", "clients.write"
+	};
+
+	/**
+	 * The user client id
+	 */
+	public static final String USER_CLIENT_ID = "app-broker-user-client";
+
+	/**
+	 * The user client secret
+	 */
+	public static final String USER_CLIENT_SECRET = "app-broker-user-client-secret";
+
+	/**
+	 * The user client authorities
+	 */
+	public static final String[] USER_CLIENT_AUTHORITIES = {
+		"cloud_controller.read", "cloud_controller.write"
 	};
 
 	@Bean

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/fixtures/cf/UserCloudFoundryService.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/fixtures/cf/UserCloudFoundryService.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.acceptance.fixtures.cf;
+
+import java.util.Map;
+
+import org.cloudfoundry.operations.CloudFoundryOperations;
+import org.cloudfoundry.operations.DefaultCloudFoundryOperations;
+import org.cloudfoundry.operations.services.CreateServiceInstanceRequest;
+import org.cloudfoundry.operations.services.DeleteServiceInstanceRequest;
+import org.cloudfoundry.operations.services.GetServiceInstanceRequest;
+import org.cloudfoundry.operations.services.ServiceInstance;
+import org.cloudfoundry.operations.services.UpdateServiceInstanceRequest;
+import org.cloudfoundry.reactor.client.ReactorCloudFoundryClient;
+import org.cloudfoundry.reactor.tokenprovider.ClientCredentialsGrantTokenProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+import org.springframework.stereotype.Service;
+
+import static org.springframework.cloud.appbroker.acceptance.fixtures.cf.CloudFoundryClientConfiguration.USER_CLIENT_ID;
+import static org.springframework.cloud.appbroker.acceptance.fixtures.cf.CloudFoundryClientConfiguration.USER_CLIENT_SECRET;
+
+@Service
+public final class UserCloudFoundryService {
+
+	private static final Logger LOG = LoggerFactory.getLogger(UserCloudFoundryService.class);
+
+	private final CloudFoundryOperations cloudFoundryOperations;
+	private final String targetOrg;
+	private final String targetSpace;
+
+	public UserCloudFoundryService(CloudFoundryOperations cloudFoundryOperations, CloudFoundryProperties cloudFoundryProperties) {
+		DefaultCloudFoundryOperations sourceCloudFoundryOperations =
+			(DefaultCloudFoundryOperations) cloudFoundryOperations;
+
+		this.targetOrg = cloudFoundryProperties.getDefaultOrg() + "-instances";
+		this.targetSpace = cloudFoundryProperties.getDefaultSpace();
+
+		ClientCredentialsGrantTokenProvider tokenProvider = ClientCredentialsGrantTokenProvider.builder()
+			.clientId(USER_CLIENT_ID)
+			.clientSecret(USER_CLIENT_SECRET)
+			.build();
+
+		ReactorCloudFoundryClient cloudFoundryClient = ReactorCloudFoundryClient.builder()
+			.from((ReactorCloudFoundryClient) sourceCloudFoundryOperations.getCloudFoundryClient())
+			.tokenProvider(tokenProvider)
+			.build();
+
+		this.cloudFoundryOperations = DefaultCloudFoundryOperations
+			.builder()
+			.from(sourceCloudFoundryOperations)
+			.space(targetSpace)
+			.organization(targetOrg)
+			.cloudFoundryClient(cloudFoundryClient)
+			.build();
+	}
+
+	public String getOrgName() {
+		return this.targetOrg;
+	}
+
+	public String getSpaceName() {
+		return this.targetSpace;
+	}
+
+	public Mono<Void> deleteServiceInstance(String serviceInstanceName) {
+		return getServiceInstance(serviceInstanceName)
+			.flatMap(si -> cloudFoundryOperations.services().deleteInstance(DeleteServiceInstanceRequest.builder()
+				.name(si.getName())
+				.build())
+				.doOnSuccess(v -> LOG.info("Success deleting service instance. serviceInstanceName={}",
+					serviceInstanceName))
+				.doOnError(e -> LOG.error(String.format("Error deleting service instance. serviceInstanceName=%s, " +
+					"error=%s", serviceInstanceName, e.getMessage()), e))
+				.onErrorResume(e -> Mono.empty()))
+			.doOnError(e -> LOG.warn(String.format("Error getting service instance. serviceInstanceName=%s, " +
+				"error=%s", serviceInstanceName, e.getMessage()), e))
+			.onErrorResume(e -> Mono.empty());
+	}
+
+	public Mono<Void> createServiceInstance(String planName,
+		String serviceName,
+		String serviceInstanceName,
+		Map<String, Object> parameters) {
+		return cloudFoundryOperations.services().createInstance(CreateServiceInstanceRequest.builder()
+			.planName(planName)
+			.serviceName(serviceName)
+			.serviceInstanceName(serviceInstanceName)
+			.parameters(parameters)
+			.build())
+			.doOnSuccess(item -> LOG.info("Success creating service instance. serviceInstanceName={}",
+				serviceInstanceName))
+			.doOnError(e -> LOG.error(String.format("Error creating service instance. serviceInstanceName=%s, " +
+				"error=%s", serviceInstanceName, e.getMessage()), e));
+	}
+
+	public Mono<Void> updateServiceInstance(String serviceInstanceName, Map<String, Object> parameters) {
+		return cloudFoundryOperations.services()
+			.updateInstance(UpdateServiceInstanceRequest.builder()
+				.serviceInstanceName(serviceInstanceName)
+				.parameters(parameters)
+				.build())
+			.doOnSuccess(item -> LOG.info("Updated service instance " + serviceInstanceName))
+			.doOnError(error -> LOG.error("Error updating service instance " + serviceInstanceName + ": " + error));
+	}
+
+	public Mono<ServiceInstance> getServiceInstance(String serviceInstanceName) {
+		return cloudFoundryOperations.services()
+			.getInstance(GetServiceInstanceRequest.builder()
+				.name(serviceInstanceName)
+				.build())
+			.doOnSuccess(item -> LOG.info("Got service instance " + serviceInstanceName))
+			.doOnError(error -> LOG.error("Error getting service instance " + serviceInstanceName + ": " + error));
+	}
+}

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/manager/BackingAppManagementService.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/manager/BackingAppManagementService.java
@@ -56,8 +56,32 @@ public class BackingAppManagementService {
 		this.targetService = targetService;
 	}
 
+	/**
+	 * Helper method that fetches service name and plan name from Cloud Foundry Service Instances API (CF API) and
+	 * invokes {@code stop(serviceInstanceId, serviceName, planName)}.
+	 *
+	 * Because this method will try to fetch user-created service instance, UAA client used by the broker has to be a
+	 * space developer of the space containing the service instance, or has to have {@code cloud_controller.admin}
+	 * authority. If you want to avoid CF API call, use
+	 * {@link BackingAppManagementService#stop(String, String, String)} method.
+	 *
+	 * @param serviceInstanceId target service instance id
+	 * @return completes when the operation is completed
+	 */
 	public Mono<Void> stop(String serviceInstanceId) {
-		return getBackingApplicationsForService(serviceInstanceId)
+		return fetchServiceDetailsAndInvoke(serviceInstanceId, this::stop);
+	}
+
+
+	/**
+	 * Stops the backing applications for the service instance with the given id
+	 * @param serviceInstanceId target service instance id
+	 * @param serviceName service name
+	 * @param planName plan name
+	 * @return completes when the operation is completed
+	 */
+	public Mono<Void> stop(String serviceInstanceId, String serviceName, String planName) {
+		return getBackingApplicationsForService(serviceInstanceId, serviceName, planName)
 			.flatMapMany(backingApps -> Flux.fromIterable(backingApps)
 				.parallel()
 				.runOn(Schedulers.parallel())
@@ -77,8 +101,31 @@ public class BackingAppManagementService {
 			.then();
 	}
 
+	/**
+	 * Helper method that fetches service name and plan name from Cloud Foundry Service Instances API (CF API) and
+	 * invokes {@code start(serviceInstanceId, serviceName, planName)}.
+	 *
+	 * Because this method will try to fetch user-created service instance, UAA client used by the broker has to be a
+	 * space developer of the space containing the service instance, or has to have {@code cloud_controller.admin}
+	 * authority. If you want to avoid CF API call, use
+	 * {@link BackingAppManagementService#start(String, String, String)} method.
+	 *
+	 * @param serviceInstanceId target service instance id
+	 * @return completes when the operation is completed
+	 */
 	public Mono<Void> start(String serviceInstanceId) {
-		return getBackingApplicationsForService(serviceInstanceId)
+		return fetchServiceDetailsAndInvoke(serviceInstanceId, this::start);
+	}
+
+	/**
+	 * Starts the backing applications for the service instance with the given id
+	 * @param serviceInstanceId target service instance id
+	 * @param serviceName service name
+	 * @param planName plan name
+	 * @return completes when the operation is completed
+	 */
+	public Mono<Void> start(String serviceInstanceId, String serviceName, String planName) {
+		return getBackingApplicationsForService(serviceInstanceId, serviceName, planName)
 			.flatMapMany(backingApps -> Flux.fromIterable(backingApps)
 				.parallel()
 				.runOn(Schedulers.parallel())
@@ -98,8 +145,31 @@ public class BackingAppManagementService {
 			.then();
 	}
 
+	/**
+	 * Helper method that fetches service name and plan name from Cloud Foundry Service Instances API (CF API) and
+	 * invokes {@code restart(serviceInstanceId, serviceName, planName)}.
+	 *
+	 * Because this method will try to fetch user-created service instance, UAA client used by the broker has to be a
+	 * space developer of the space containing the service instance, or has to have {@code cloud_controller.admin}
+	 * authority. If you want to avoid CF API call, use
+	 * {@link BackingAppManagementService#restart(String, String, String)} method.
+	 *
+	 * @param serviceInstanceId target service instance id
+	 * @return completes when the operation is completed
+	 */
 	public Mono<Void> restart(String serviceInstanceId) {
-		return getBackingApplicationsForService(serviceInstanceId)
+		return fetchServiceDetailsAndInvoke(serviceInstanceId, this::restart);
+	}
+
+	/**
+	 * Restarts the backing applications for the service instance with the given id
+	 * @param serviceInstanceId target service instance id
+	 * @param serviceName service name
+	 * @param planName plan name
+	 * @return completes when the operation is completed
+	 */
+	public Mono<Void> restart(String serviceInstanceId, String serviceName, String planName) {
+		return getBackingApplicationsForService(serviceInstanceId, serviceName, planName)
 			.flatMapMany(backingApps -> Flux.fromIterable(backingApps)
 				.parallel()
 				.runOn(Schedulers.parallel())
@@ -119,8 +189,31 @@ public class BackingAppManagementService {
 			.then();
 	}
 
+	/**
+	 * Helper method that fetches service name and plan name from Cloud Foundry Service Instances API (CF API) and
+	 * invokes {@code restage(serviceInstanceId, serviceName, planName)}.
+	 *
+	 * Because this method will try to fetch user-created service instance, UAA client used by the broker has to be a
+	 * space developer of the space containing the service instance, or has to have {@code cloud_controller.admin}
+	 * authority. If you want to avoid CF API call, use
+	 * {@link BackingAppManagementService#restage(String, String, String)} method.
+	 *
+	 * @param serviceInstanceId target service instance id
+	 * @return completes when the operation is completed
+	 */
 	public Mono<Void> restage(String serviceInstanceId) {
-		return getBackingApplicationsForService(serviceInstanceId)
+		return fetchServiceDetailsAndInvoke(serviceInstanceId, this::restage);
+	}
+
+	/**
+	 * Restages the backing applications for the service instance with the given id
+	 * @param serviceInstanceId target service instance id
+	 * @param serviceName service name
+	 * @param planName plan name
+	 * @return completes when the operation is completed
+	 */
+	public Mono<Void> restage(String serviceInstanceId, String serviceName, String planName) {
+		return getBackingApplicationsForService(serviceInstanceId, serviceName, planName)
 			.flatMapMany(backingApps -> Flux.fromIterable(backingApps)
 				.parallel()
 				.runOn(Schedulers.parallel())
@@ -140,8 +233,31 @@ public class BackingAppManagementService {
 			.then();
 	}
 
+	/**
+	 * Helper method that fetches service name and plan name from Cloud Foundry Service Instances API (CF API) and
+	 * invokes {@code getDeployedBackingApplications(serviceInstanceId, serviceName, planName)}.
+	 *
+	 * Because this method will try to fetch user-created service instance, UAA client used by the broker has to be a
+	 * space developer of the space containing the service instance, or has to have {@code cloud_controller.admin}
+	 * authority. If you want to avoid CF API call, use
+	 * {@link BackingAppManagementService#getDeployedBackingApplications(String, String, String)} method.
+	 *
+	 * @param serviceInstanceId target service instance id
+	 * @return backing applications for the target service instance
+	 */
 	public Mono<BackingApplications> getDeployedBackingApplications(String serviceInstanceId) {
-		return getBackingApplicationsForService(serviceInstanceId)
+		return fetchServiceDetailsAndInvoke(serviceInstanceId, this::getDeployedBackingApplications);
+	}
+
+	/**
+	 * Returns a list of backing applications for the service instance with the given id
+	 * @param serviceInstanceId target service instance id
+	 * @param serviceName service name
+	 * @param planName plan name
+	 * @return backing applications for the target service instance
+	 */
+	public Mono<BackingApplications> getDeployedBackingApplications(String serviceInstanceId, String serviceName, String planName) {
+		return getBackingApplicationsForService(serviceInstanceId, serviceName, planName)
 			.flatMapMany(Flux::fromIterable)
 			.flatMap(app ->
 				appDeployer
@@ -150,9 +266,9 @@ public class BackingAppManagementService {
 						.properties(app.getProperties())
 						.build())
 					.flatMap(response -> Flux.fromIterable(response.getServices())
-						.map(serviceName ->
+						.map(boundServiceName ->
 							ServicesSpec.builder()
-								.serviceInstanceName(serviceName)
+								.serviceInstanceName(boundServiceName)
 								.build())
 						.collectList()
 						.map(services -> BackingApplication
@@ -176,13 +292,18 @@ public class BackingAppManagementService {
 			.doOnSuccess(backingApplications -> LOG.debug("backingApplications={}", backingApplications));
 	}
 
-	private Mono<BackingApplications> getBackingApplicationsForService(String serviceInstanceId) {
-		return appDeployer.getServiceInstance(GetServiceInstanceRequest.builder()
-			.serviceInstanceId(serviceInstanceId)
-			.build())
-			.flatMap(response -> findBrokeredService(response.getService(), response.getPlan()))
+	public Mono<BackingApplications> getBackingApplicationsForService(String serviceInstanceId, String serviceName,
+		String planName) {
+		return findBrokeredService(serviceName, planName)
 			.flatMap(brokeredService -> updateBackingApps(brokeredService, serviceInstanceId))
 			.map(backingApplications -> BackingApplications.builder().backingApplications(backingApplications).build());
+	}
+
+	private <T> Mono<T> fetchServiceDetailsAndInvoke(String serviceInstanceId, BackingAppAction<T> action) {
+		return appDeployer
+			.getServiceInstance(GetServiceInstanceRequest.builder().serviceInstanceId(serviceInstanceId).build())
+			.flatMap(serviceInstance -> action.invoke(serviceInstanceId, serviceInstance.getService(),
+				serviceInstance.getPlan()));
 	}
 
 	private Mono<BrokeredService> findBrokeredService(String serviceName, String planName) {
@@ -199,6 +320,11 @@ public class BackingAppManagementService {
 			.build())
 			.flatMap(backingApps -> targetService.addToBackingApplications(backingApps,
 				brokeredService.getTarget(), serviceInstanceId));
+	}
+
+	@FunctionalInterface
+	private interface BackingAppAction<T> {
+		Mono<T> invoke(String serviceInstanceId, String serviceName, String planName);
 	}
 
 }

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentDeleteServiceInstanceWorkflow.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentDeleteServiceInstanceWorkflow.java
@@ -124,7 +124,8 @@ public class AppDeploymentDeleteServiceInstanceWorkflow
 	}
 
 	private Flux<BackingService> collectBoundBackingServices(DeleteServiceInstanceRequest request) {
-		return backingAppManagementService.getDeployedBackingApplications(request.getServiceInstanceId())
+		return backingAppManagementService.getDeployedBackingApplications(request.getServiceInstanceId(),
+			request.getServiceDefinition().getName(), request.getPlan().getName())
 			.flatMapMany(Flux::fromIterable)
 			.flatMap(backingApplication -> Mono.justOrEmpty(backingApplication.getServices())
 				.flatMapMany(Flux::fromIterable)

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentUpdateServiceInstanceWorkflow.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentUpdateServiceInstanceWorkflow.java
@@ -144,7 +144,8 @@ public class AppDeploymentUpdateServiceInstanceWorkflow extends AppDeploymentIns
 	}
 
 	private Mono<Map<String, BackingService>> getExistingBackingServiceNameMap(UpdateServiceInstanceRequest request) {
-		return backingAppManagementService.getDeployedBackingApplications(request.getServiceInstanceId())
+		return backingAppManagementService.getDeployedBackingApplications(request.getServiceInstanceId(),
+			request.getServiceDefinition().getName(), request.getPlan().getName())
 			.flatMapMany(Flux::fromIterable)
 			.map(BackingApplication::getServices)
 			.flatMap(Flux::fromIterable)

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentDeleteServiceInstanceWorkflowTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentDeleteServiceInstanceWorkflowTest.java
@@ -172,7 +172,8 @@ class AppDeploymentDeleteServiceInstanceWorkflowTest {
 			.willReturn(Mono.just(backingServices));
 
 		// services bound to deployed apps
-		given(this.backingAppManagementService.getDeployedBackingApplications(eq(request.getServiceInstanceId())))
+		given(this.backingAppManagementService.getDeployedBackingApplications(request.getServiceInstanceId(),
+			request.getServiceDefinition().getName(), request.getPlan().getName()))
 			.willReturn(Mono.just(getExistingBackingAppsWithService("my-service-instance")));
 		given(this.credentialProviderService.deleteCredentials(eq(backingApps), eq(request.getServiceInstanceId())))
 			.willReturn(Mono.just(backingApps));
@@ -208,7 +209,8 @@ class AppDeploymentDeleteServiceInstanceWorkflowTest {
 			.willReturn(Mono.just(backingServices2));
 
 		// different bound services
-		given(this.backingAppManagementService.getDeployedBackingApplications(eq(request.getServiceInstanceId())))
+		given(this.backingAppManagementService.getDeployedBackingApplications(request.getServiceInstanceId(),
+			request.getServiceDefinition().getName(), request.getPlan().getName()))
 			.willReturn(Mono.just(getExistingBackingAppsWithService("different-service-instance")));
 		given(this.credentialProviderService.deleteCredentials(eq(backingApps), eq(request.getServiceInstanceId())))
 			.willReturn(Mono.just(backingApps));
@@ -240,7 +242,8 @@ class AppDeploymentDeleteServiceInstanceWorkflowTest {
 		DeleteServiceInstanceRequest request = buildRequest("unsupported-service", "plan1");
 		DeleteServiceInstanceResponse response = DeleteServiceInstanceResponse.builder().build();
 
-		given(this.backingAppManagementService.getDeployedBackingApplications(eq(request.getServiceInstanceId())))
+		given(this.backingAppManagementService.getDeployedBackingApplications(request.getServiceInstanceId(),
+			request.getServiceDefinition().getName(), request.getPlan().getName()))
 			.willReturn(Mono.empty());
 
 		StepVerifier
@@ -260,7 +263,8 @@ class AppDeploymentDeleteServiceInstanceWorkflowTest {
 			.willReturn(Mono.just(backingServices));
 
 		// no backing apps
-		given(this.backingAppManagementService.getDeployedBackingApplications(eq(request.getServiceInstanceId())))
+		given(this.backingAppManagementService.getDeployedBackingApplications(request.getServiceInstanceId(),
+			request.getServiceDefinition().getName(), request.getPlan().getName()))
 			.willReturn(Mono.empty());
 
 		given(this.backingServicesProvisionService.deleteServiceInstance(argThat(backingServices -> {

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentUpdateServiceInstanceWorkflowTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentUpdateServiceInstanceWorkflowTest.java
@@ -182,7 +182,8 @@ class AppDeploymentUpdateServiceInstanceWorkflowTest {
 		UpdateServiceInstanceResponse response = UpdateServiceInstanceResponse.builder().build();
 
 		setupMocks(request);
-		given(this.backingAppManagementService.getDeployedBackingApplications(eq(request.getServiceInstanceId())))
+		given(this.backingAppManagementService.getDeployedBackingApplications(request.getServiceInstanceId(),
+			request.getServiceDefinition().getName(), request.getPlan().getName()))
 			.willReturn(Mono.just(getExistingBackingAppsWithService("existing-service-instance")));
 		given(this.servicesProvisionService.createServiceInstance(any()))
 			.willReturn(Flux.just("my-service-instance"));
@@ -214,7 +215,8 @@ class AppDeploymentUpdateServiceInstanceWorkflowTest {
 		UpdateServiceInstanceRequest request = buildRequest("unsupported-service", "plan1");
 		UpdateServiceInstanceResponse response = UpdateServiceInstanceResponse.builder().build();
 
-		given(this.backingAppManagementService.getDeployedBackingApplications(eq(request.getServiceInstanceId())))
+		given(this.backingAppManagementService.getDeployedBackingApplications(request.getServiceInstanceId(),
+			request.getServiceDefinition().getName(), request.getPlan().getName()))
 			.willReturn(Mono.empty());
 
 		StepVerifier
@@ -250,7 +252,8 @@ class AppDeploymentUpdateServiceInstanceWorkflowTest {
 		given(this.servicesProvisionService.deleteServiceInstance(any()))
 			.willReturn(Flux.empty());
 
-		given(this.backingAppManagementService.getDeployedBackingApplications(eq(request.getServiceInstanceId())))
+		given(this.backingAppManagementService.getDeployedBackingApplications(request.getServiceInstanceId(),
+			request.getServiceDefinition().getName(), request.getPlan().getName()))
 			.willReturn(Mono.just(getExistingBackingAppsWithService("my-service-instance")));
 	}
 

--- a/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/CreateInstanceWithOAuth2CredentialsComponentTest.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/CreateInstanceWithOAuth2CredentialsComponentTest.java
@@ -128,8 +128,6 @@ class CreateInstanceWithOAuth2CredentialsComponentTest extends WiremockComponent
 
 	@Test
 	void deleteAppWithOAuth2Credentials() {
-		cloudControllerFixture.stubGetServiceInstanceWithNoBinding("instance-id", "instance-name",
-							SERVICE_NAME, PLAN_NAME);
 		cloudControllerFixture.stubAppExists(APP_NAME_1);
 		cloudControllerFixture.stubServiceBindingDoesNotExist(APP_NAME_1);
 		cloudControllerFixture.stubDeleteApp(APP_NAME_1);

--- a/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/DeleteInstanceComponentTest.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/DeleteInstanceComponentTest.java
@@ -60,9 +60,6 @@ class DeleteInstanceComponentTest extends WiremockComponentTest {
 
 	@Test
 	void deleteAppsWhenTheyExist() {
-		cloudControllerFixture.stubGetServiceInstanceWithNoBinding("instance-id", "instance-name",
-					SERVICE_NAME, PLAN_NAME);
-
 		cloudControllerFixture.stubAppExists(APP_NAME_1);
 		cloudControllerFixture.stubAppExists(APP_NAME_2);
 
@@ -93,9 +90,6 @@ class DeleteInstanceComponentTest extends WiremockComponentTest {
 
 	@Test
 	void deleteAppsWhenTheyDoNotExist() {
-		cloudControllerFixture.stubGetServiceInstanceWithNoBinding("instance-id", "instance-name",
-					SERVICE_NAME, PLAN_NAME);
-
 		cloudControllerFixture.stubAppDoesNotExist(APP_NAME_1);
 		cloudControllerFixture.stubAppDoesNotExist(APP_NAME_2);
 

--- a/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/DeleteInstanceWithAppsAndServicesComponentTest.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/DeleteInstanceWithAppsAndServicesComponentTest.java
@@ -69,8 +69,6 @@ class DeleteInstanceWithAppsAndServicesComponentTest extends WiremockComponentTe
 
 	@Test
 	void deleteAppsAndServicesWhenTheyExist() {
-		cloudControllerFixture.stubGetServiceInstanceWithNoBinding("instance-id", "instance-name",
-							SERVICE_NAME, PLAN_NAME);
 		cloudControllerFixture.stubAppExistsWithBackingService(APP_NAME, BACKING_SI_NAME,
 			BACKING_SERVICE_NAME, BACKING_PLAN_NAME);
 		cloudControllerFixture.stubServiceBindingDoesNotExist(APP_NAME);
@@ -103,8 +101,6 @@ class DeleteInstanceWithAppsAndServicesComponentTest extends WiremockComponentTe
 
 	@Test
 	void deleteAppsWhenTheyExistAndServicesWhenTheyDoNotExist() {
-		cloudControllerFixture.stubGetServiceInstanceWithNoBinding("instance-id", "instance-name",
-							SERVICE_NAME, PLAN_NAME);
 		cloudControllerFixture.stubAppExists(APP_NAME);
 		cloudControllerFixture.stubServiceBindingDoesNotExist(APP_NAME);
 		cloudControllerFixture.stubDeleteApp(APP_NAME);
@@ -130,8 +126,6 @@ class DeleteInstanceWithAppsAndServicesComponentTest extends WiremockComponentTe
 
 	@Test
 	void deleteAppsAndServicesWhenTheyDoNotExist() {
-		cloudControllerFixture.stubGetServiceInstanceWithNoBinding("instance-id", "instance-name",
-							SERVICE_NAME, PLAN_NAME);
 		cloudControllerFixture.stubAppDoesNotExist(APP_NAME);
 
 		// when the service instance is deleted

--- a/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/DeleteInstanceWithServicesComponentTest.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/DeleteInstanceWithServicesComponentTest.java
@@ -63,9 +63,6 @@ class DeleteInstanceWithServicesComponentTest extends WiremockComponentTest {
 
 	@Test
 	void deleteServicesWhenTheyExist() {
-		cloudControllerFixture.stubGetServiceInstanceWithNoBinding("instance-id", "instance-name",
-			SERVICE_NAME, PLAN_NAME);
-
 		cloudControllerFixture.stubGetBackingServiceInstance(BACKING_SI_NAME, BACKING_SERVICE_NAME, BACKING_PLAN_NAME);
 
 		cloudControllerFixture.stubServiceBindingsDoNotExist(BACKING_SI_NAME);
@@ -92,9 +89,6 @@ class DeleteInstanceWithServicesComponentTest extends WiremockComponentTest {
 
 	@Test
 	void deleteServicesWhenTheyDoNotExist() {
-		cloudControllerFixture.stubGetServiceInstanceWithNoBinding("instance-id", "instance-name",
-							SERVICE_NAME, PLAN_NAME);
-
 		// when the service instance is deleted
 		given(brokerFixture.serviceInstanceRequest())
 			.when()

--- a/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/UpdateInstanceWithNewServiceComponentTest.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/UpdateInstanceWithNewServiceComponentTest.java
@@ -76,8 +76,6 @@ class UpdateInstanceWithNewServiceComponentTest extends WiremockComponentTest {
 	void updateAppWithNewService() {
 		cloudControllerFixture.stubAppExistsWithBackingService(APP_NAME, BACKING_SI_NAME,
 			BACKING_SERVICE_NAME, BACKING_PLAN_NAME);
-		cloudControllerFixture.stubGetServiceInstanceWithNoBinding("instance-id", "instance-name",
-			SERVICE_NAME, PLAN_NAME);
 		cloudControllerFixture.stubUpdateApp(APP_NAME);
 
 		// will unbind and delete the existing service instance

--- a/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/UpdateInstanceWithServicesComponentTest.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/UpdateInstanceWithServicesComponentTest.java
@@ -70,8 +70,6 @@ class UpdateInstanceWithServicesComponentTest extends WiremockComponentTest {
 	void updateAppWithServices() {
 		cloudControllerFixture.stubAppExistsWithBackingService(APP_NAME, BACKING_SERVICE_INSTANCE_NAME,
 			BACKING_SERVICE_NAME, BACKING_PLAN_NAME);
-		cloudControllerFixture.stubGetServiceInstanceWithNoBinding("instance-id", "instance-name",
-			SERVICE_NAME, PLAN_NAME);
 		cloudControllerFixture.stubUpdateApp(APP_NAME);
 
 		// when a service instance is updated

--- a/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/UpdateInstanceWithServicesParametersComponentTest.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/UpdateInstanceWithServicesParametersComponentTest.java
@@ -75,8 +75,6 @@ class UpdateInstanceWithServicesParametersComponentTest extends WiremockComponen
 	void updateAppWithBackingServicesParameters() {
 		cloudControllerFixture.stubAppExistsWithBackingService(APP_NAME, BACKING_SI_NAME, BACKING_SERVICE_NAME,
 			BACKING_PLAN_NAME);
-		cloudControllerFixture.stubGetServiceInstanceWithNoBinding("instance-id", "instance-name",
-			SERVICE_NAME, PLAN_NAME);
 		cloudControllerFixture.stubUpdateApp(APP_NAME);
 
 		// will update with filtered parameters and bind the service instance

--- a/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/UpdateInstanceWithServicesRebindComponentTest.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/UpdateInstanceWithServicesRebindComponentTest.java
@@ -71,8 +71,6 @@ class UpdateInstanceWithServicesRebindComponentTest extends WiremockComponentTes
 	void updateAppWithServices() {
 		cloudControllerFixture.stubAppExistsWithBackingService(APP_NAME, BACKING_SI_NAME, BACKING_SERVICE_NAME,
 			BACKING_PLAN_NAME);
-		cloudControllerFixture.stubGetServiceInstanceWithNoBinding("instance-id", "instance-name",
-			SERVICE_NAME, PLAN_NAME);
 		cloudControllerFixture.stubUpdateApp(APP_NAME);
 
 		cloudControllerFixture.stubGetBackingServiceInstance(BACKING_SI_NAME, BACKING_SERVICE_NAME, BACKING_PLAN_NAME);

--- a/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/fixtures/CloudControllerStubFixture.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/fixtures/CloudControllerStubFixture.java
@@ -471,27 +471,6 @@ public class CloudControllerStubFixture extends WiremockStubFixture {
 					replace("@guid", serviceInstanceId)))));
 	}
 
-	public void stubGetServiceInstanceWithNoBinding(String serviceInstanceId, String serviceInstanceName, String serviceName,
-		String planName) {
-		stubFor(get(urlPathEqualTo("/v2/service_instances/" + serviceInstanceId))
-			.willReturn(ok()
-				.withBody(cc("get-service_instance",
-					replace("@space-guid", TEST_SPACE_GUID),
-					replace("@service-guid", serviceGuid(serviceName)),
-					replace("@plan-guid", planGuid(planName)),
-					replace("@name", serviceInstanceName),
-					replace("@guid", serviceInstanceId)))));
-
-		stubServiceInstanceExists(serviceInstanceId, serviceInstanceName, serviceName, planName);
-		stubFor(get(urlPathEqualTo("/v2/service_bindings"))
-			.withQueryParam("q", equalTo("service_instance_guid:" + serviceInstanceId))
-			.withQueryParam("page", equalTo("1"))
-			.willReturn(ok()
-				.withBody(cc("empty-query-results"))));
-
-		stubGetServiceAndGetPlan(serviceName, planName);
-	}
-
 	public void stubServiceBindingsDoNotExist(String serviceInstanceName) {
 		stubFor(get(urlPathEqualTo("/v2/service_bindings"))
 			.withQueryParam("q", equalTo("service_instance_guid:" + serviceInstanceGuid(serviceInstanceName)))


### PR DESCRIPTION
Calling /v2/service_instance/<id> requires the broker client to be
either space developer of a user's space or have `cloud_controller.admin`
authority. To remove this requirement, BackingAppManagementService was
updated to accept service and plan name as arguments, so now getting
these values is a responsibility of a caller. In case of update / delete
both values can be extracted from the request, for management operations
they now have to be provided.

Also, this commit introduces ATs refactoring to make sure App Broker can
work without `cc.admin` permissions and without being a org manager.
This is done by separating CloudFoundryService to User and Broker
implementations. UserCloudFoundryService can only create / update /
delete service instances in own space and org, which broker UAA client
has no access to. BrokerCloudFoundryService can work with the backing
apps, services, spaces etc.