### PR TITLE
Stop log streaming if listener is dropped

### DIFF
--- a/spring-cloud-app-broker-logging/src/main/java/org/springframework/cloud/appbroker/logging/streaming/endpoint/StreamingLogWebSocketHandler.java
+++ b/spring-cloud-app-broker-logging/src/main/java/org/springframework/cloud/appbroker/logging/streaming/endpoint/StreamingLogWebSocketHandler.java
@@ -84,8 +84,10 @@ public class StreamingLogWebSocketHandler implements WebSocketHandler, Applicati
 		EmitterProcessor<Envelope> processor = this.processors.get(event.getServiceInstanceId());
 		if (processor == null) {
 			if (LOG.isWarnEnabled()) {
-				LOG.warn("No processor found for {}, can't stream logs", event.getServiceInstanceId());
+				LOG.warn("No processor found for {}, stopping log streaming", event.getServiceInstanceId());
 			}
+
+			eventPublisher.publishEvent(new StopServiceInstanceLoggingEvent(this, event.getServiceInstanceId()));
 
 			return;
 		}

--- a/spring-cloud-app-broker-logging/src/test/java/com/example/streaming/LogStreamingTestApp.java
+++ b/spring-cloud-app-broker-logging/src/test/java/com/example/streaming/LogStreamingTestApp.java
@@ -37,6 +37,7 @@ public class LogStreamingTestApp {
 	static final String APP_ID = UUID.randomUUID().toString();
 
 	static boolean receivedStopEvent;
+	static String receivedStopEventServiceInstanceId;
 
 	public static String getAppId() {
 		return APP_ID;
@@ -46,6 +47,10 @@ public class LogStreamingTestApp {
 		return receivedStopEvent;
 	}
 
+	public static String getReceivedStopEventServiceInstanceId() {
+		return receivedStopEventServiceInstanceId;
+	}
+
 	@Bean
 	ApplicationIdsProvider applicationIdsProvider() {
 		return serviceInstanceId -> Flux.just(APP_ID);
@@ -53,6 +58,7 @@ public class LogStreamingTestApp {
 
 	@EventListener
 	public void onStop(StopServiceInstanceLoggingEvent stopServiceInstanceLoggingEvent) {
+		receivedStopEventServiceInstanceId = stopServiceInstanceLoggingEvent.getServiceInstanceId();
 		receivedStopEvent = true;
 	}
 


### PR DESCRIPTION
CLI plugin doesn't always handle disconnect gracefully, so sometimes it is possible that log stream is being published but there is no listener. In this case log streaming should be stopped.