### PR TITLE
Updates to the staging process

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -79,6 +79,7 @@ jobs:
       - get: release-ci-image
       - get: git-repo
         trigger: false
+        passed: [run-acceptance-tests]
       - task: stage
         image: release-ci-image
         file: git-repo/ci/tasks/stage.yml
@@ -97,6 +98,7 @@ jobs:
       - get: release-ci-image
       - get: git-repo
         trigger: false
+        passed: [run-acceptance-tests]
       - task: stage
         image: release-ci-image
         file: git-repo/ci/tasks/stage.yml
@@ -115,6 +117,7 @@ jobs:
       - get: release-ci-image
       - get: git-repo
         trigger: false
+        passed: [run-acceptance-tests]
       - task: stage
         image: release-ci-image
         file: git-repo/ci/tasks/stage.yml
@@ -258,6 +261,7 @@ resources:
       password: ((github-password))
       branch: ((branch))
       ignore_paths: ["ci/images/*"]
+      fetch_tags: true
   - name: ci-images-git-repo
     type: git
     source:
@@ -283,9 +287,7 @@ resources:
     source:
       url: {{scs-slack-webhook}}
 groups:
-  - name: "Build"
-    jobs: ["build", "run-acceptance-tests"]
-  - name: "Release"
-    jobs: ["stage-milestone", "stage-rc", "stage-release", "promote-milestone", "promote-rc", "promote-release", "distribute-release", "sync-to-maven-central"]
+  - name: "Main"
+    jobs: ["build", "run-acceptance-tests", "stage-milestone", "stage-rc", "stage-release", "promote-milestone", "promote-rc", "promote-release", "distribute-release", "sync-to-maven-central"]
   - name: "CI Images"
     jobs: ["build-release-ci-images"]

--- a/ci/scripts/stage.sh
+++ b/ci/scripts/stage.sh
@@ -1,51 +1,55 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 # shellcheck source=scripts/common.sh
 source "$(dirname "$0")/common.sh"
 repository=$(pwd)/distribution-repository
 
-pushd git-repo >/dev/null
-git fetch --tags --all >/dev/null
-popd >/dev/null
-
-git clone git-repo stage-git-repo >/dev/null
+git clone git-repo stage-git-repo
+echo
 
 pushd stage-git-repo >/dev/null
+git config user.name "Spring Buildmaster"
+git config user.email "buildmaster@springframework.org"
 
 snapshotVersion=$(awk -F '=' '$1 == "version" { print $2 }' gradle.properties)
 if [[ $RELEASE_TYPE == "M" ]]; then
-  stageVersion=$(get_next_milestone_release $snapshotVersion)
-  nextVersion=$snapshotVersion
+  stageVersion=$(get_next_milestone_release "$snapshotVersion")
+  nextVersion="$snapshotVersion"
 elif [[ $RELEASE_TYPE == "RC" ]]; then
-  stageVersion=$(get_next_rc_release $snapshotVersion)
-  nextVersion=$snapshotVersion
+  stageVersion=$(get_next_rc_release "$snapshotVersion")
+  nextVersion="$snapshotVersion"
 elif [[ $RELEASE_TYPE == "RELEASE" ]]; then
-  stageVersion=$(get_next_release $snapshotVersion)
-  nextVersion=$(bump_version_number $snapshotVersion)
+  stageVersion=$(get_next_release "$snapshotVersion")
+  nextVersion=$(bump_version_number "$snapshotVersion")
 else
   echo "Unknown release type $RELEASE_TYPE" >&2
   exit 1
 fi
 
-echo "Staging $stageVersion (next version will be $nextVersion)"
+echo "Current version is v$snapshotVersion"
+echo "Version to stage is v$stageVersion"
+echo "Next development version will be v$nextVersion"
+echo
+
+git checkout -b "merge-on-success/$stageVersion"
+echo
+
+echo "Tagging version being staged (v$stageVersion)"
 sed -i "s/version=$snapshotVersion/version=$stageVersion/" gradle.properties
+git add gradle.properties
+git commit -m "Release v$stageVersion"
+git tag -a "v$stageVersion" -m "Release v$stageVersion"
+echo
 
-git config user.name "Spring Buildmaster" >/dev/null
-git config user.email "buildmaster@springframework.org" >/dev/null
-git add gradle.properties >/dev/null
-git commit -m"Release v$stageVersion" >/dev/null
-git tag -a "v$stageVersion" -m"Release v$stageVersion" >/dev/null
+./gradlew --no-daemon clean install -Dmaven.repo.local="${repository}"
+echo
 
-./gradlew --no-daemon clean build install -Dmaven.repo.local="${repository}"
-
-git reset --hard HEAD^ >/dev/null
-if [[ $nextVersion != $snapshotVersion ]]; then
-  echo "Setting next development version (v$nextVersion)"
-  sed -i "s/version=$snapshotVersion/version=$nextVersion/" gradle.properties
-  git add gradle.properties >/dev/null
-  git commit -m"Next development version (v$nextVersion)" >/dev/null
-fi
+echo "Setting next development version (v$nextVersion)"
+sed -i "s/version=$stageVersion/version=$nextVersion/" gradle.properties
+git add gradle.properties
+git commit -m "Next development version (v$nextVersion)"
+echo
 
 echo "DONE"
 


### PR DESCRIPTION
* Pipeline now fetches tags so the task doesn't have to
* Staging jobs now take git versions that have passed ATs. This avoids
the need to run all the tests again, taking staging down from ~20 mins
to ~2
* Version bumps are done on a branch to avoid pushing to protected
`master branch`
* Debug output and script tidying