### PR TITLE
Replace docker-image resource with registry-image

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -204,13 +204,13 @@ jobs:
 
 resource_types:
   - name: artifactory-resource
-    type: docker-image
+    type: registry-image
     source:
       repository: springio/artifactory-resource
       tag: 0.0.12
 
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
       repository: cfcommunity/slack-notification-resource
       tag: latest
@@ -242,7 +242,7 @@ resources:
       paths: ["ci/images/*"]
 
   - name: release-ci-image
-    type: docker-image
+    type: registry-image
     source:
       repository: ((docker-hub-organization))/release-ci-image
       username: ((docker-hub-username))

--- a/ci/pr-pipeline.yml
+++ b/ci/pr-pipeline.yml
@@ -47,12 +47,12 @@ jobs:
 
 resource_types:
   - name: pull-request
-    type: docker-image
+    type: registry-image
     source:
       repository: teliaoss/github-pr-resource
 
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
       repository: cfcommunity/slack-notification-resource
       tag: latest

--- a/ci/tasks/acceptance-tests.yml
+++ b/ci/tasks/acceptance-tests.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: openjdk
     tag: 8


### PR DESCRIPTION
This can make use of the global Concourse registry mirror, which is
authenticated to avoid DockerHub rate limits.

#403