### PR TITLE
Pre-update of backing applications

### DIFF
--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/fixtures/cf/CloudFoundryClientConfiguration.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/fixtures/cf/CloudFoundryClientConfiguration.java
@@ -75,7 +75,7 @@ public class CloudFoundryClientConfiguration {
 	protected CloudFoundryOperations cloudFoundryOperations(CloudFoundryProperties properties,
 		CloudFoundryClient client,
 		DopplerClient dopplerClient,
-		UaaClient uaaClient) {
+		@Qualifier("userCredentials") UaaClient uaaClient) {
 		return DefaultCloudFoundryOperations.builder()
 			.cloudFoundryClient(client)
 			.dopplerClient(dopplerClient)
@@ -114,7 +114,18 @@ public class CloudFoundryClientConfiguration {
 	}
 
 	@Bean
-	protected UaaClient uaaClient(ConnectionContext connectionContext,
+	@Qualifier("userCredentials")
+	protected UaaClient userCredentialsUaaClient(ConnectionContext connectionContext,
+		@Qualifier("userCredentials") TokenProvider tokenProvider) {
+		return ReactorUaaClient.builder()
+			.connectionContext(connectionContext)
+			.tokenProvider(tokenProvider)
+			.build();
+	}
+
+	@Bean
+	@Qualifier("clientCredentials")
+	protected UaaClient clientCredentialsUaaClient(ConnectionContext connectionContext,
 		@Qualifier("clientCredentials") TokenProvider tokenProvider) {
 		return ReactorUaaClient.builder()
 			.connectionContext(connectionContext)

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/fixtures/cf/CloudFoundryService.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/fixtures/cf/CloudFoundryService.java
@@ -176,10 +176,13 @@ public class CloudFoundryService {
 	}
 
 	public Mono<Void> deleteApp(String appName) {
-		return cloudFoundryOperations.applications().delete(DeleteApplicationRequest.builder()
-			.name(appName)
-			.deleteRoutes(true)
-			.build())
+		return cloudFoundryOperations.applications().list()
+			.filter(app -> appName.equals(app.getName()))
+			.singleOrEmpty()
+			.flatMap(app -> cloudFoundryOperations.applications().delete(DeleteApplicationRequest.builder()
+				.name(appName)
+				.deleteRoutes(true)
+				.build()))
 			.doOnSuccess(item -> LOG.info("Success deleting app. appName={}", appName))
 			.doOnError(e -> LOG.warn(String.format("Error deleting app. appName=%s, error=%s", appName,
 				e.getMessage()), e))
@@ -187,9 +190,12 @@ public class CloudFoundryService {
 	}
 
 	public Mono<Void> deleteServiceBroker(String brokerName) {
-		return cloudFoundryOperations.serviceAdmin().delete(DeleteServiceBrokerRequest.builder()
-			.name(brokerName)
-			.build())
+		return cloudFoundryOperations.serviceAdmin().list()
+			.filter(serviceBroker -> brokerName.equals(serviceBroker.getName()))
+			.singleOrEmpty()
+			.flatMap(serviceBroker -> cloudFoundryOperations.serviceAdmin()
+				.delete(DeleteServiceBrokerRequest.builder().name(brokerName).build())
+			)
 			.doOnSuccess(item -> LOG.info("Success deleting service broker. brokerName={}", brokerName))
 			.doOnError(e -> LOG.warn(String.format("Error deleting service broker. brokerName=%s, error=%s ",
 				brokerName, e.getMessage()), e))

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/BackingAppDeploymentService.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/BackingAppDeploymentService.java
@@ -36,6 +36,17 @@ public interface BackingAppDeploymentService {
 	Flux<String> deploy(List<BackingApplication> backingApps, String serviceInstanceId);
 
 	/**
+	 * Performs any steps necessary prior to backing application and backing service updates
+	 *
+	 * @param backingApps a collection of backing applications
+	 * @param serviceInstanceId the service instance ID
+	 * @return a set of strings, where each corresponds to an application. e.g. the application name
+	 */
+	default Flux<String> prepareForUpdate(List<BackingApplication> backingApps, String serviceInstanceId) {
+		return Flux.empty();
+	}
+
+	/**
 	 * Update the backing applications and associate with the service instance
 	 *
 	 * @param backingApps a collection of backing applications

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/DeployerClient.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/DeployerClient.java
@@ -26,10 +26,6 @@ public class DeployerClient {
 
 	private static final Logger LOG = Loggers.getLogger(DeployerClient.class);
 
-	private static final String BACKINGAPP_LOG_TEMPLATE = "backingApp={}";
-
-	private static final String BACKINGSERVICE_LOG_TEMPLATE = "backingService={}";
-
 	private final AppDeployer appDeployer;
 
 	public DeployerClient(AppDeployer appDeployer) {
@@ -51,45 +47,53 @@ public class DeployerClient {
 				.build())
 			.doOnRequest(l -> {
 				LOG.info("Deploying application. backingAppName={}", backingApplication.getName());
-				LOG.debug(BACKINGAPP_LOG_TEMPLATE, backingApplication);
+				debugLog(backingApplication);
 			})
 			.doOnSuccess(response -> {
 				LOG.info("Success deploying application. backingAppName={}", backingApplication.getName());
-				LOG.debug("response={}, backingApp={}", response, backingApplication);
+				debugLog(response, backingApplication);
 			})
 			.doOnError(e -> {
 				LOG.error(String.format("Error deploying application. backingAppName=%s, error=%s",
 					backingApplication.getName(), e.getMessage()), e);
-				LOG.debug(BACKINGAPP_LOG_TEMPLATE, backingApplication);
+				debugLog(backingApplication);
 			})
 			.map(DeployApplicationResponse::getName);
 	}
 
+	public Mono<String> preUpdate(BackingApplication backingApplication, String serviceInstanceId) {
+		return appDeployer.preUpdate(getUpdateApplicationRequest(backingApplication, serviceInstanceId))
+			.doOnRequest(l -> {
+				LOG.info("Pre-updating application. backingAppName={}", backingApplication.getName());
+				debugLog(backingApplication);
+			})
+			.doOnSuccess(response -> {
+				LOG.info("Success pre-updating application. backingAppName={}", backingApplication.getName());
+				debugLog(response, backingApplication);
+			})
+			.doOnError(e -> {
+				LOG.error(String.format("Error pre-updating application. backingAppName=%s, error=%s",
+					backingApplication.getName(), e.getMessage()), e);
+				debugLog(backingApplication);
+			})
+			.map(UpdateApplicationResponse::getName);
+	}
+
 	public Mono<String> update(BackingApplication backingApplication, String serviceInstanceId) {
 		return appDeployer
-			.update(UpdateApplicationRequest
-				.builder()
-				.name(backingApplication.getName())
-				.path(backingApplication.getPath())
-				.properties(backingApplication.getProperties())
-				.environment(backingApplication.getEnvironment())
-				.services(backingApplication.getServices().stream()
-					.map(ServicesSpec::getServiceInstanceName)
-					.collect(Collectors.toList()))
-				.serviceInstanceId(serviceInstanceId)
-				.build())
+			.update(getUpdateApplicationRequest(backingApplication, serviceInstanceId))
 			.doOnRequest(l -> {
 				LOG.info("Updating application. backingAppName={}", backingApplication.getName());
-				LOG.debug(BACKINGAPP_LOG_TEMPLATE, backingApplication);
+				debugLog(backingApplication);
 			})
 			.doOnSuccess(response -> {
 				LOG.info("Success updating application. backingAppName={}", backingApplication.getName());
-				LOG.debug("response={}, backingApp={}", response, backingApplication);
+				debugLog(response, backingApplication);
 			})
 			.doOnError(e -> {
 				LOG.error(String.format("Error updating application. backingAppName=%s, error=%s",
 					backingApplication.getName(), e.getMessage()), e);
-				LOG.debug(BACKINGAPP_LOG_TEMPLATE, backingApplication);
+				debugLog(backingApplication);
 			})
 			.map(UpdateApplicationResponse::getName);
 	}
@@ -103,16 +107,16 @@ public class DeployerClient {
 				.build())
 			.doOnRequest(l -> {
 				LOG.info("Undeploying application. backingAppName={}", backingApplication.getName());
-				LOG.debug(BACKINGAPP_LOG_TEMPLATE, backingApplication);
+				debugLog(backingApplication);
 			})
 			.doOnSuccess(response -> {
 				LOG.info("Success undeploying application. backingAppName={}", backingApplication.getName());
-				LOG.debug("response={}, backingApp={}", response, backingApplication);
+				debugLog(response, backingApplication);
 			})
 			.doOnError(e -> {
 				LOG.error(String.format("Error undeploying application. backingAppName=%s, error=%s",
 					backingApplication.getName(), e.getMessage()), e);
-				LOG.debug(BACKINGAPP_LOG_TEMPLATE, backingApplication);
+				debugLog(backingApplication);
 			})
 			.onErrorReturn(UndeployApplicationResponse.builder()
 				.name(backingApplication.getName())
@@ -133,16 +137,16 @@ public class DeployerClient {
 					.build())
 			.doOnRequest(l -> {
 				LOG.info("Creating backing service {}", backingService.getName());
-				LOG.debug(BACKINGSERVICE_LOG_TEMPLATE, backingService);
+				debugLog(backingService);
 			})
 			.doOnSuccess(response -> {
 				LOG.info("Success creating backing service {}", backingService.getName());
-				LOG.debug("response={}, backingService={}", response, backingService);
+				debugLog(response, backingService);
 			})
 			.doOnError(e -> {
 				LOG.error(String.format("Error creating backing service. backingServiceName=%s, error=%s",
 					backingService.getName(), e.getMessage()), e);
-				LOG.debug(BACKINGSERVICE_LOG_TEMPLATE, backingService);
+				debugLog(backingService);
 			})
 			.map(CreateServiceInstanceResponse::getName);
 	}
@@ -159,16 +163,16 @@ public class DeployerClient {
 					.build())
 			.doOnRequest(l -> {
 				LOG.info("Updating backing service {}", backingService.getName());
-				LOG.debug(BACKINGSERVICE_LOG_TEMPLATE, backingService);
+				debugLog(backingService);
 			})
 			.doOnSuccess(response -> {
 				LOG.info("Success updating backing service {}", backingService.getName());
-				LOG.debug("response={}, backingService={}", response, backingService);
+				debugLog(response, backingService);
 			})
 			.doOnError(e -> {
 				LOG.error(String.format("Error updating backing service. backingServiceName=%s, error=%s",
 					backingService.getName(), e.getMessage()), e);
-				LOG.debug(BACKINGSERVICE_LOG_TEMPLATE, backingService);
+				debugLog(backingService);
 			})
 			.map(UpdateServiceInstanceResponse::getName);
 	}
@@ -183,16 +187,16 @@ public class DeployerClient {
 					.build())
 			.doOnRequest(l -> {
 				LOG.info("Deleting backing service {}", backingService.getName());
-				LOG.debug(BACKINGSERVICE_LOG_TEMPLATE, backingService);
+				debugLog(backingService);
 			})
 			.doOnSuccess(response -> {
 				LOG.info("Success deleting backing service {}", backingService.getName());
-				LOG.debug("response={}, backingService={}", response, backingService);
+				debugLog(response, backingService);
 			})
 			.doOnError(e -> {
 				LOG.error(String.format("Error deleting backing service. backingServiceName=%s, error=%s",
 					backingService.getName(), e.getMessage()), e);
-				LOG.debug(BACKINGSERVICE_LOG_TEMPLATE, backingService);
+				debugLog(backingService);
 			})
 			.onErrorReturn(DeleteServiceInstanceResponse.builder()
 				.name(backingService.getServiceInstanceName())
@@ -200,4 +204,34 @@ public class DeployerClient {
 			.map(DeleteServiceInstanceResponse::getName);
 	}
 
+	private static UpdateApplicationRequest getUpdateApplicationRequest(BackingApplication backingApplication,
+		String serviceInstanceId) {
+		return UpdateApplicationRequest
+			.builder()
+			.name(backingApplication.getName())
+			.path(backingApplication.getPath())
+			.properties(backingApplication.getProperties())
+			.environment(backingApplication.getEnvironment())
+			.services(backingApplication.getServices().stream()
+				.map(ServicesSpec::getServiceInstanceName)
+				.collect(Collectors.toList()))
+			.serviceInstanceId(serviceInstanceId)
+			.build();
+	}
+
+	private static void debugLog(BackingApplication backingApplication) {
+		LOG.debug("backingApp={}", backingApplication);
+	}
+
+	private static void debugLog(BackingService backingService) {
+		LOG.debug("backingService={}", backingService);
+	}
+
+	private static void debugLog(Object response, BackingApplication backingApplication) {
+		LOG.debug("response={}, backingApp={}", response, backingApplication);
+	}
+
+	private static void debugLog(Object response, BackingService backingService) {
+		LOG.debug("response={}, backingService={}", response, backingService);
+	}
 }

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/deployer/DefaultBackingAppDeploymentServiceTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/deployer/DefaultBackingAppDeploymentServiceTest.java
@@ -55,7 +55,6 @@ class DefaultBackingAppDeploymentServiceTest {
 	}
 
 	@Test
-	@SuppressWarnings("UnassignedFluxMonoInstance")
 	void shouldDeployApplications() {
 		doReturn(Mono.just("app1"))
 			.when(deployerClient).deploy(backingApps.get(0), "instance-id");
@@ -75,7 +74,44 @@ class DefaultBackingAppDeploymentServiceTest {
 	}
 
 	@Test
-	@SuppressWarnings("UnassignedFluxMonoInstance")
+	void shouldPrepareApplicationsForUpdate() {
+		doReturn(Mono.just("app1"))
+			.when(deployerClient).preUpdate(backingApps.get(0), "instance-id");
+		doReturn(Mono.just("app2"))
+			.when(deployerClient).preUpdate(backingApps.get(1), "instance-id");
+
+		List<String> expectedValues = new ArrayList<>();
+		expectedValues.add("app1");
+		expectedValues.add("app2");
+
+		StepVerifier.create(backingAppDeploymentService.prepareForUpdate(backingApps, "instance-id"))
+			// update preparations are run in parallel, so the order of completion is not predictable
+			// ensure that both expected signals are sent in any order
+			.expectNextMatches(expectedValues::remove)
+			.expectNextMatches(expectedValues::remove)
+			.verifyComplete();
+	}
+
+	@Test
+	void shouldUpdateApplications() {
+		doReturn(Mono.just("app1"))
+			.when(deployerClient).update(backingApps.get(0), "instance-id");
+		doReturn(Mono.just("app2"))
+			.when(deployerClient).update(backingApps.get(1), "instance-id");
+
+		List<String> expectedValues = new ArrayList<>();
+		expectedValues.add("app1");
+		expectedValues.add("app2");
+
+		StepVerifier.create(backingAppDeploymentService.update(backingApps, "instance-id"))
+			// updates are run in parallel, so the order of completion is not predictable
+			// ensure that both expected signals are sent in any order
+			.expectNextMatches(expectedValues::remove)
+			.expectNextMatches(expectedValues::remove)
+			.verifyComplete();
+	}
+
+	@Test
 	void shouldUndeployApplications() {
 		doReturn(Mono.just("deleted1"))
 			.when(deployerClient).undeploy(backingApps.get(0));

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/deployer/DeployerClientTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/deployer/DeployerClientTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatcher;
@@ -52,248 +53,7 @@ class DeployerClientTest {
 	@Mock
 	private AppDeployer appDeployer;
 
-	@BeforeEach
-	void setUp() {
-		deployerClient = new DeployerClient(appDeployer);
-	}
-
-	@Test
-	void shouldDeployApp() {
-		// given
-		setupAppDeployer();
-
-		BackingApplication application = BackingApplication.builder()
-			.name(APP_NAME)
-			.path(APP_PATH)
-			.build();
-
-		// when
-		StepVerifier.create(deployerClient.deploy(application, "instance-id"))
-			// then
-			.expectNext(APP_NAME)
-			.verifyComplete();
-
-		then(appDeployer).should().deploy(argThat(matchesRequest(APP_NAME, APP_PATH, Collections.emptyMap(),
-			Collections.emptyMap(), Collections.emptyList())));
-	}
-
-	@Test
-	@SuppressWarnings("serial")
-	void shouldDeployAppWithProperties() {
-		setupAppDeployer();
-
-		Map<String, String> properties = new HashMap<String, String>() {{
-			put("memory", "1G");
-			put("instances", "2");
-		}};
-		BackingApplication application = BackingApplication.builder()
-			.name(APP_NAME)
-			.path(APP_PATH)
-			.properties(properties)
-			.build();
-
-		// when
-		StepVerifier.create(deployerClient.deploy(application, "instance-id"))
-			// then
-			.expectNext(APP_NAME)
-			.verifyComplete();
-
-		then(appDeployer).should().deploy(argThat(matchesRequest(APP_NAME, APP_PATH, properties,
-			Collections.emptyMap(), Collections.emptyList())));
-	}
-
-	@Test
-	@SuppressWarnings("serial")
-	void shouldDeployAppWithService() {
-		setupAppDeployer();
-
-		BackingApplication application =
-			BackingApplication
-				.builder()
-				.name(APP_NAME)
-				.path(APP_PATH)
-				.services(ServicesSpec.builder()
-					.serviceInstanceName("my-db-service")
-					.build())
-				.build();
-
-		// when
-		StepVerifier.create(deployerClient.deploy(application, "instance-id"))
-			// then
-			.expectNext(APP_NAME)
-			.verifyComplete();
-
-		then(appDeployer).should().deploy(argThat(matchesRequest(APP_NAME, APP_PATH, Collections.emptyMap(),
-			Collections.emptyMap(), Collections.singletonList("my-db-service"))));
-	}
-
-	@Test
-	@SuppressWarnings("serial")
-	void shouldDeployAppWithEnvironmentVariables() {
-		setupAppDeployer();
-
-		Map<String, Object> environment = new HashMap<String, Object>() {{
-			put("ENV_VAR_1", "value1");
-			put("ENV_VAR_2", "value2");
-		}};
-		BackingApplication application = BackingApplication.builder()
-			.name(APP_NAME)
-			.path(APP_PATH)
-			.environment(environment)
-			.build();
-
-		// when
-		StepVerifier.create(deployerClient.deploy(application, "instance-id"))
-			// then
-			.expectNext(APP_NAME)
-			.verifyComplete();
-
-		then(appDeployer).should().deploy(argThat(matchesRequest(APP_NAME, APP_PATH, Collections.emptyMap(),
-			environment, Collections.emptyList())));
-	}
-
-	@Test
-	void shouldUndeployApp() {
-		given(appDeployer.undeploy(any()))
-			.willReturn(Mono.just(UndeployApplicationResponse.builder()
-				.name(APP_NAME)
-				.build()));
-
-		BackingApplication application = BackingApplication.builder()
-			.name(APP_NAME)
-			.path(APP_PATH)
-			.build();
-
-		// when
-		StepVerifier.create(deployerClient.undeploy(application))
-			// then
-			.expectNext(APP_NAME)
-			.verifyComplete();
-
-		then(appDeployer).should().undeploy(argThat(request -> APP_NAME.equals(request.getName())));
-	}
-
-	@Test
-	void shouldNotReturnErrorWhenUndeployingAppThatDoesNotExist() {
-		given(appDeployer.undeploy(any()))
-			.willReturn(Mono.error(new IllegalStateException("app does not exist")));
-
-		BackingApplication application = BackingApplication.builder()
-			.name(APP_NAME)
-			.path(APP_PATH)
-			.build();
-
-		// when
-		StepVerifier.create(deployerClient.undeploy(application))
-			// then
-			.expectNext(APP_NAME)
-			.verifyComplete();
-
-		then(appDeployer).should().undeploy(argThat(request -> APP_NAME.equals(request.getName())));
-	}
-
-	@Test
-	void shouldCreateServiceInstance() {
-		given(appDeployer.createServiceInstance(any()))
-			.willReturn(Mono.just(CreateServiceInstanceResponse.builder()
-				.name(SERVICE_INSTANCE_NAME)
-				.build()));
-
-		BackingService service = BackingService.builder()
-			.serviceInstanceName(SERVICE_INSTANCE_NAME)
-			.build();
-
-		// when
-		StepVerifier.create(deployerClient.createServiceInstance(service))
-			// then
-			.expectNext(SERVICE_INSTANCE_NAME)
-			.verifyComplete();
-
-		then(appDeployer).should().createServiceInstance(argThat(request ->
-			SERVICE_INSTANCE_NAME.equals(request.getServiceInstanceName())));
-	}
-
-	@Test
-	void shouldUpdateServiceInstance() {
-		given(appDeployer.updateServiceInstance(any()))
-			.willReturn(Mono.just(UpdateServiceInstanceResponse.builder()
-				.name(SERVICE_INSTANCE_NAME)
-				.build()));
-
-		BackingService service = BackingService.builder()
-			.serviceInstanceName(SERVICE_INSTANCE_NAME)
-			.build();
-
-		// when
-		StepVerifier.create(deployerClient.updateServiceInstance(service))
-			// then
-			.expectNext(SERVICE_INSTANCE_NAME)
-			.verifyComplete();
-
-		then(appDeployer).should().updateServiceInstance(argThat(request ->
-			SERVICE_INSTANCE_NAME.equals(request.getServiceInstanceName())));
-	}
-
-	@Test
-	void shouldReturnErrorWhenUpdatingServiceInstanceThatDoesNotExist() {
-		given(appDeployer.updateServiceInstance(any()))
-			.willReturn(Mono.error(new IllegalStateException("service instance does not exist")));
-
-		BackingService service = BackingService.builder()
-			.serviceInstanceName(SERVICE_INSTANCE_NAME)
-			.build();
-
-		// when
-		StepVerifier.create(deployerClient.updateServiceInstance(service))
-			// then
-			.expectErrorMessage("service instance does not exist")
-			.verify();
-
-		then(appDeployer).should().updateServiceInstance(argThat(request ->
-			SERVICE_INSTANCE_NAME.equals(request.getServiceInstanceName())));
-	}
-
-	@Test
-	void shouldDeleteServiceInstance() {
-		given(appDeployer.deleteServiceInstance(any()))
-			.willReturn(Mono.just(DeleteServiceInstanceResponse.builder()
-				.name(SERVICE_INSTANCE_NAME)
-				.build()));
-
-		BackingService service = BackingService.builder()
-			.serviceInstanceName(SERVICE_INSTANCE_NAME)
-			.build();
-
-		// when
-		StepVerifier.create(deployerClient.deleteServiceInstance(service))
-			// then
-			.expectNext(SERVICE_INSTANCE_NAME)
-			.verifyComplete();
-
-		then(appDeployer).should().deleteServiceInstance(argThat(request ->
-			SERVICE_INSTANCE_NAME.equals(request.getServiceInstanceName())));
-	}
-
-	@Test
-	void shouldNotReturnErrorWhenDeletingServiceInstanceThatDoesNotExist() {
-		given(appDeployer.deleteServiceInstance(any()))
-			.willReturn(Mono.error(new IllegalStateException("service instance does not exist")));
-
-		BackingService service = BackingService.builder()
-			.serviceInstanceName(SERVICE_INSTANCE_NAME)
-			.build();
-
-		// when
-		StepVerifier.create(deployerClient.deleteServiceInstance(service))
-			// then
-			.expectNext(SERVICE_INSTANCE_NAME)
-			.verifyComplete();
-
-		then(appDeployer).should().deleteServiceInstance(argThat(request ->
-			SERVICE_INSTANCE_NAME.equals(request.getServiceInstanceName())));
-	}
-
-	private ArgumentMatcher<DeployApplicationRequest> matchesRequest(String appName, String appArchive,
+	private static ArgumentMatcher<DeployApplicationRequest> matchesDeploymentRequest(String appName, String appArchive,
 		Map<String, String> properties,
 		Map<String, Object> environment,
 		List<String> services) {
@@ -305,11 +65,359 @@ class DeployerClientTest {
 				request.getServices().equals(services);
 	}
 
-	private void setupAppDeployer() {
-		given(appDeployer.deploy(any()))
-			.willReturn(Mono.just(DeployApplicationResponse.builder()
+	private static ArgumentMatcher<UpdateApplicationRequest> matchesUpdateRequest(String appName, String appArchive,
+		Map<String, String> properties,
+		Map<String, Object> environment,
+		List<String> services,
+		String serviceInstanceId) {
+		return request ->
+			request.getName().equals(appName) &&
+				request.getPath().equals(appArchive) &&
+				request.getProperties().equals(properties) &&
+				request.getEnvironment().equals(environment) &&
+				request.getServices().equals(services) &&
+				request.getServiceInstanceId().equals(serviceInstanceId);
+	}
+
+	@BeforeEach
+	void setUp() {
+		deployerClient = new DeployerClient(appDeployer);
+	}
+
+	@Nested
+	class Deploy {
+
+		@Test
+		void shouldDeployApp() {
+			// given
+			setupAppDeployer();
+
+			BackingApplication application = BackingApplication.builder()
 				.name(APP_NAME)
-				.build()));
+				.path(APP_PATH)
+				.build();
+
+			// when
+			StepVerifier.create(deployerClient.deploy(application, "instance-id"))
+				// then
+				.expectNext(APP_NAME)
+				.verifyComplete();
+
+			then(appDeployer).should()
+				.deploy(argThat(matchesDeploymentRequest(APP_NAME, APP_PATH, Collections.emptyMap(),
+					Collections.emptyMap(), Collections.emptyList())));
+		}
+
+		@Test
+		@SuppressWarnings("serial")
+		void shouldDeployAppWithProperties() {
+			setupAppDeployer();
+
+			Map<String, String> properties = new HashMap<String, String>() {{
+				put("memory", "1G");
+				put("instances", "2");
+			}};
+			BackingApplication application = BackingApplication.builder()
+				.name(APP_NAME)
+				.path(APP_PATH)
+				.properties(properties)
+				.build();
+
+			// when
+			StepVerifier.create(deployerClient.deploy(application, "instance-id"))
+				// then
+				.expectNext(APP_NAME)
+				.verifyComplete();
+
+			then(appDeployer).should().deploy(argThat(matchesDeploymentRequest(APP_NAME, APP_PATH, properties,
+				Collections.emptyMap(), Collections.emptyList())));
+		}
+
+		@Test
+		@SuppressWarnings("serial")
+		void shouldDeployAppWithService() {
+			setupAppDeployer();
+
+			BackingApplication application =
+				BackingApplication
+					.builder()
+					.name(APP_NAME)
+					.path(APP_PATH)
+					.services(ServicesSpec.builder()
+						.serviceInstanceName("my-db-service")
+						.build())
+					.build();
+
+			// when
+			StepVerifier.create(deployerClient.deploy(application, "instance-id"))
+				// then
+				.expectNext(APP_NAME)
+				.verifyComplete();
+
+			then(appDeployer).should()
+				.deploy(argThat(matchesDeploymentRequest(APP_NAME, APP_PATH, Collections.emptyMap(),
+					Collections.emptyMap(), Collections.singletonList("my-db-service"))));
+		}
+
+		@Test
+		@SuppressWarnings("serial")
+		void shouldDeployAppWithEnvironmentVariables() {
+			setupAppDeployer();
+
+			Map<String, Object> environment = new HashMap<String, Object>() {{
+				put("ENV_VAR_1", "value1");
+				put("ENV_VAR_2", "value2");
+			}};
+			BackingApplication application = BackingApplication.builder()
+				.name(APP_NAME)
+				.path(APP_PATH)
+				.environment(environment)
+				.build();
+
+			// when
+			StepVerifier.create(deployerClient.deploy(application, "instance-id"))
+				// then
+				.expectNext(APP_NAME)
+				.verifyComplete();
+
+			then(appDeployer).should()
+				.deploy(argThat(matchesDeploymentRequest(APP_NAME, APP_PATH, Collections.emptyMap(),
+					environment, Collections.emptyList())));
+		}
+
+		private void setupAppDeployer() {
+			given(appDeployer.deploy(any()))
+				.willReturn(Mono.just(DeployApplicationResponse.builder()
+					.name(APP_NAME)
+					.build()));
+		}
+	}
+
+	@Nested
+	class PreUpdate {
+
+		@Test
+		void shouldPrepareAppForUpdate() {
+			// given
+			setupAppDeployer();
+			final String serviceInstanceId = "instance-id";
+
+			BackingApplication application = BackingApplication.builder()
+				.name(APP_NAME)
+				.path(APP_PATH)
+				.build();
+
+			// when
+			StepVerifier.create(deployerClient.preUpdate(application, serviceInstanceId))
+				// then
+				.expectNext(APP_NAME)
+				.verifyComplete();
+
+			then(appDeployer).should().preUpdate(argThat(matchesUpdateRequest(APP_NAME,
+				APP_PATH, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyList(), serviceInstanceId)));
+		}
+
+
+		private void setupAppDeployer() {
+			given(appDeployer.preUpdate(any()))
+				.willReturn(Mono.just(UpdateApplicationResponse.builder()
+					.name(APP_NAME)
+					.build()));
+		}
+	}
+
+	@Nested
+	class Update {
+
+		@Test
+		void shouldUpdateApp() {
+			// given
+			setupAppDeployer();
+			final String serviceInstanceId = "instance-id";
+
+			BackingApplication application = BackingApplication.builder()
+				.name(APP_NAME)
+				.path(APP_PATH)
+				.build();
+
+			// when
+			StepVerifier.create(deployerClient.update(application, serviceInstanceId))
+				// then
+				.expectNext(APP_NAME)
+				.verifyComplete();
+
+			then(appDeployer).should().update(argThat(matchesUpdateRequest(APP_NAME,
+				APP_PATH, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyList(), serviceInstanceId)));
+		}
+
+
+		private void setupAppDeployer() {
+			given(appDeployer.update(any()))
+				.willReturn(Mono.just(UpdateApplicationResponse.builder()
+					.name(APP_NAME)
+					.build()));
+		}
+	}
+
+	@Nested
+	class Undeploy {
+
+		@Test
+		void shouldUndeployApp() {
+			given(appDeployer.undeploy(any()))
+				.willReturn(Mono.just(UndeployApplicationResponse.builder()
+					.name(APP_NAME)
+					.build()));
+
+			BackingApplication application = BackingApplication.builder()
+				.name(APP_NAME)
+				.path(APP_PATH)
+				.build();
+
+			// when
+			StepVerifier.create(deployerClient.undeploy(application))
+				// then
+				.expectNext(APP_NAME)
+				.verifyComplete();
+
+			then(appDeployer).should().undeploy(argThat(request -> APP_NAME.equals(request.getName())));
+		}
+
+		@Test
+		void shouldNotReturnErrorWhenUndeployingAppThatDoesNotExist() {
+			given(appDeployer.undeploy(any()))
+				.willReturn(Mono.error(new IllegalStateException("app does not exist")));
+
+			BackingApplication application = BackingApplication.builder()
+				.name(APP_NAME)
+				.path(APP_PATH)
+				.build();
+
+			// when
+			StepVerifier.create(deployerClient.undeploy(application))
+				// then
+				.expectNext(APP_NAME)
+				.verifyComplete();
+
+			then(appDeployer).should().undeploy(argThat(request -> APP_NAME.equals(request.getName())));
+		}
+
+	}
+
+	@Nested
+	class CreateServiceInstance {
+
+		@Test
+		void shouldCreateServiceInstance() {
+			given(appDeployer.createServiceInstance(any()))
+				.willReturn(Mono.just(CreateServiceInstanceResponse.builder()
+					.name(SERVICE_INSTANCE_NAME)
+					.build()));
+
+			BackingService service = BackingService.builder()
+				.serviceInstanceName(SERVICE_INSTANCE_NAME)
+				.build();
+
+			// when
+			StepVerifier.create(deployerClient.createServiceInstance(service))
+				// then
+				.expectNext(SERVICE_INSTANCE_NAME)
+				.verifyComplete();
+
+			then(appDeployer).should().createServiceInstance(argThat(request ->
+				SERVICE_INSTANCE_NAME.equals(request.getServiceInstanceName())));
+		}
+
+	}
+
+	@Nested
+	class UpdateServiceInstance {
+
+		@Test
+		void shouldUpdateServiceInstance() {
+			given(appDeployer.updateServiceInstance(any()))
+				.willReturn(Mono.just(UpdateServiceInstanceResponse.builder()
+					.name(SERVICE_INSTANCE_NAME)
+					.build()));
+
+			BackingService service = BackingService.builder()
+				.serviceInstanceName(SERVICE_INSTANCE_NAME)
+				.build();
+
+			// when
+			StepVerifier.create(deployerClient.updateServiceInstance(service))
+				// then
+				.expectNext(SERVICE_INSTANCE_NAME)
+				.verifyComplete();
+
+			then(appDeployer).should().updateServiceInstance(argThat(request ->
+				SERVICE_INSTANCE_NAME.equals(request.getServiceInstanceName())));
+		}
+
+		@Test
+		void shouldReturnErrorWhenUpdatingServiceInstanceThatDoesNotExist() {
+			given(appDeployer.updateServiceInstance(any()))
+				.willReturn(Mono.error(new IllegalStateException("service instance does not exist")));
+
+			BackingService service = BackingService.builder()
+				.serviceInstanceName(SERVICE_INSTANCE_NAME)
+				.build();
+
+			// when
+			StepVerifier.create(deployerClient.updateServiceInstance(service))
+				// then
+				.expectErrorMessage("service instance does not exist")
+				.verify();
+
+			then(appDeployer).should().updateServiceInstance(argThat(request ->
+				SERVICE_INSTANCE_NAME.equals(request.getServiceInstanceName())));
+		}
+
+	}
+
+	@Nested
+	class DeleteServiceInstance {
+
+		@Test
+		void shouldDeleteServiceInstance() {
+			given(appDeployer.deleteServiceInstance(any()))
+				.willReturn(Mono.just(DeleteServiceInstanceResponse.builder()
+					.name(SERVICE_INSTANCE_NAME)
+					.build()));
+
+			BackingService service = BackingService.builder()
+				.serviceInstanceName(SERVICE_INSTANCE_NAME)
+				.build();
+
+			// when
+			StepVerifier.create(deployerClient.deleteServiceInstance(service))
+				// then
+				.expectNext(SERVICE_INSTANCE_NAME)
+				.verifyComplete();
+
+			then(appDeployer).should().deleteServiceInstance(argThat(request ->
+				SERVICE_INSTANCE_NAME.equals(request.getServiceInstanceName())));
+		}
+
+		@Test
+		void shouldNotReturnErrorWhenDeletingServiceInstanceThatDoesNotExist() {
+			given(appDeployer.deleteServiceInstance(any()))
+				.willReturn(Mono.error(new IllegalStateException("service instance does not exist")));
+
+			BackingService service = BackingService.builder()
+				.serviceInstanceName(SERVICE_INSTANCE_NAME)
+				.build();
+
+			// when
+			StepVerifier.create(deployerClient.deleteServiceInstance(service))
+				// then
+				.expectNext(SERVICE_INSTANCE_NAME)
+				.verifyComplete();
+
+			then(appDeployer).should().deleteServiceInstance(argThat(request ->
+				SERVICE_INSTANCE_NAME.equals(request.getServiceInstanceName())));
+		}
+
 	}
 
 }

--- a/spring-cloud-app-broker-deployer/src/main/java/org/springframework/cloud/appbroker/deployer/AppDeployer.java
+++ b/spring-cloud-app-broker-deployer/src/main/java/org/springframework/cloud/appbroker/deployer/AppDeployer.java
@@ -24,6 +24,10 @@ public interface AppDeployer {
 		return Mono.empty();
 	}
 
+	default Mono<UpdateApplicationResponse> preUpdate(UpdateApplicationRequest request) {
+		return Mono.empty();
+	}
+
 	default Mono<UpdateApplicationResponse> update(UpdateApplicationRequest request) {
 		return Mono.empty();
 	}


### PR DESCRIPTION
The update service flow is now:
1. pre-update backing applications
2. update backing services
3. update backing applications

The Cloud Foundry implementation has a pre-update step which applies
backing application environment updates. This allows the following
backing services update step to read the updated app environment, which
is required for correct operation of some services where a rebind is
performed on update. The final update backing applications step performs
a rolling redeployment as before to ensure both environment changes and
any credential updates resulting from a rebind are propagated to the
backing apps.