### PR TITLE
Updating CFJC to 5.1

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -22,6 +22,24 @@ Join us in our gitter channel: https://gitter.im/spring-cloud-app-broker/communi
 
 === Compatibility
 
+==== 1.3.x
+
+* https://projects.spring.io/spring-framework/[Spring Framework] 5.3.x
+* https://projects.spring.io/spring-boot/[Spring Boot] 2.4.x
+* https://github.com/cloudfoundry/cf-java-client/[Cloud Foundry Java Client] 5.x
+* https://github.com/reactor/[Reactor] 3.4.x
+* https://spring.io/projects/spring-cloud-open-service-broker/[Spring Cloud Open Service Broker] 3.3.x
+* https://github.com/openservicebrokerapi/servicebroker/tree/v2.15/[Open Service Broker API] 2.15
+
+==== 1.2.x
+
+* https://projects.spring.io/spring-framework/[Spring Framework] 5.2.x
+* https://projects.spring.io/spring-boot/[Spring Boot] 2.3.x
+* https://github.com/cloudfoundry/cf-java-client/[Cloud Foundry Java Client] 4.x
+* https://github.com/reactor/[Reactor] 3.3.x
+* https://spring.io/projects/spring-cloud-open-service-broker/[Spring Cloud Open Service Broker] 3.3.x
+* https://github.com/openservicebrokerapi/servicebroker/tree/v2.15/[Open Service Broker API] 2.15
+
 ==== 1.1.x
 
 * https://projects.spring.io/spring-framework/[Spring Framework] 5.2.x

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ onlyShowStandardStreamsOnTestFailure = false
 
 awaitilityVersion = 4.0.2
 blockHoundVersion = 1.0.4.RELEASE
-cfJavaClientVersion = 4.7.0.RELEASE
+cfJavaClientVersion = 5.1.0.RELEASE
 checkstyleVersion = 8.37
 commonsTextVersion = 1.8
 immutablesVersion = 2.8.8

--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryDeploymentProperties.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryDeploymentProperties.java
@@ -114,7 +114,7 @@ public class CloudFoundryDeploymentProperties extends DeploymentProperties {
 	/**
 	 * The buildpack to use for deploying the application.
 	 */
-	private String buildpack;
+	private String buildpack = "";
 
 	/**
 	 * The type of health check to perform on deployed application, if not overridden per-app.  Defaults to PORT

--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/test/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployerTest.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/test/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployerTest.java
@@ -154,6 +154,7 @@ class CloudFoundryAppDeployerTest {
 	@BeforeEach
 	void setUp() {
 		deploymentProperties = new CloudFoundryDeploymentProperties();
+
 		CloudFoundryTargetProperties targetProperties = new CloudFoundryTargetProperties();
 		targetProperties.setDefaultOrg("default-org");
 		targetProperties.setDefaultSpace("default-space");
@@ -193,6 +194,7 @@ class CloudFoundryAppDeployerTest {
 		ApplicationManifest expectedManifest = baseManifestWithSpringAppJson()
 			.name(APP_NAME)
 			.path(new File(APP_PATH).toPath())
+			.buildpacks("") // Empty list means to discover the buildpack
 			.build();
 
 		then(operationsApplications).should().pushManifest(argThat(matchesManifest(expectedManifest)));
@@ -436,6 +438,7 @@ class CloudFoundryAppDeployerTest {
 			"\"ENV_VAR_2\":\"value2\",\"ENV_VAR_1\":\"value1\"")
 			.name(APP_NAME)
 			.path(new File(APP_PATH).toPath())
+			.buildpacks("")
 			.environmentVariable("JAVA_OPTS", "-Xms512m -Xmx1024m")
 			.build();
 
@@ -462,6 +465,7 @@ class CloudFoundryAppDeployerTest {
 		ApplicationManifest expectedManifest = baseManifest()
 			.name(APP_NAME)
 			.path(new File(APP_PATH).toPath())
+			.buildpack("")
 			.environmentVariable("JAVA_OPTS", "-Xms512m -Xmx1024m")
 			.environmentVariable("spring.cloud.appbroker.service-instance-id", SERVICE_INSTANCE_ID)
 			.environmentVariable("ENV_VAR_1", "value1")

--- a/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/WiremockComponentTest.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/WiremockComponentTest.java
@@ -50,7 +50,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 		"spring.cloud.appbroker.deployer.cloudfoundry.password=adminpass",
 		"spring.cloud.appbroker.deployer.cloudfoundry.default-org=test",
 		"spring.cloud.appbroker.deployer.cloudfoundry.default-space=development",
-		"spring.cloud.appbroker.deployer.cloudfoundry.secure=false"
+		"spring.cloud.appbroker.deployer.cloudfoundry.secure=false",
+		"spring.cloud.appbroker.deployer.cloudfoundry.properties.buildpack=example-buildpack"
 	}
 )
 @ActiveProfiles("openservicebroker-catalog")

--- a/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/fixtures/CloudControllerStubFixture.java
+++ b/spring-cloud-app-broker-integration-tests/src/test/java/org/springframework/cloud/appbroker/integration/fixtures/CloudControllerStubFixture.java
@@ -236,6 +236,7 @@ public class CloudControllerStubFixture extends WiremockStubFixture {
 	}
 
 	public void stubUpdateAppWithUpgrade(final String appName) {
+		stubGetV3App(appName);
 		stubUpdateEnvironment(appName);
 		stubCreatePackage(appName);
 		stubCreateBuild(appName);
@@ -248,10 +249,20 @@ public class CloudControllerStubFixture extends WiremockStubFixture {
 	}
 
 	public void stubUpdateApp(final String appName) {
+		stubGetV3App(appName);
 		stubUpdateEnvironment(appName);
 		stubGetPackage(appName);
 		stubCreateBuild(appName);
 		stubCreateDeployment(appName);
+	}
+
+	private void stubGetV3App(String appName) {
+		stubFor(get(urlPathEqualTo("/v3/apps/" + appGuid(appName)))
+			.willReturn(ok()
+				.withBody(cc("get-v3-app-STARTED",
+					replace("@name", appName),
+					replace("@guid",  appGuid(appName))
+				))));
 	}
 
 	private void stubAppAfterCreation(String appName, String host) {

--- a/spring-cloud-app-broker-integration-tests/src/test/resources/responses/cloudcontroller/get-v3-app-STARTED.json
+++ b/spring-cloud-app-broker-integration-tests/src/test/resources/responses/cloudcontroller/get-v3-app-STARTED.json
@@ -1,0 +1,70 @@
+{
+	"guid": "@guid",
+	"name": "@name",
+	"state": "STARTED",
+	"created_at": "2016-03-17T21:41:30Z",
+	"updated_at": "2016-06-08T16:41:26Z",
+	"lifecycle": {
+		"type": "buildpack",
+		"data": {
+			"buildpacks": [
+				"java_buildpack"
+			],
+			"stack": "cflinuxfs3"
+		}
+	},
+	"relationships": {
+		"space": {
+			"data": {
+				"guid": "@space-guid"
+			}
+		}
+	},
+	"links": {
+		"self": {
+			"href": "https://api.example.org/v3/apps/1cb006ee-fb05-47e1-b541-c34179ddc446"
+		},
+		"space": {
+			"href": "https://api.example.org/v3/spaces/2f35885d-0c9d-4423-83ad-fd05066f8576"
+		},
+		"processes": {
+			"href": "https://api.example.org/v3/apps/1cb006ee-fb05-47e1-b541-c34179ddc446/processes"
+		},
+		"packages": {
+			"href": "https://api.example.org/v3/apps/1cb006ee-fb05-47e1-b541-c34179ddc446/packages"
+		},
+		"environment_variables": {
+			"href": "https://api.example.org/v3/apps/1cb006ee-fb05-47e1-b541-c34179ddc446/environment_variables"
+		},
+		"current_droplet": {
+			"href": "https://api.example.org/v3/apps/1cb006ee-fb05-47e1-b541-c34179ddc446/droplets/current"
+		},
+		"droplets": {
+			"href": "https://api.example.org/v3/apps/1cb006ee-fb05-47e1-b541-c34179ddc446/droplets"
+		},
+		"tasks": {
+			"href": "https://api.example.org/v3/apps/1cb006ee-fb05-47e1-b541-c34179ddc446/tasks"
+		},
+		"start": {
+			"href": "https://api.example.org/v3/apps/1cb006ee-fb05-47e1-b541-c34179ddc446/actions/start",
+			"method": "POST"
+		},
+		"stop": {
+			"href": "https://api.example.org/v3/apps/1cb006ee-fb05-47e1-b541-c34179ddc446/actions/stop",
+			"method": "POST"
+		},
+		"revisions": {
+			"href": "https://api.example.org/v3/apps/1cb006ee-fb05-47e1-b541-c34179ddc446/revisions"
+		},
+		"deployed_revisions": {
+			"href": "https://api.example.org/v3/apps/1cb006ee-fb05-47e1-b541-c34179ddc446/revisions/deployed"
+		},
+		"features": {
+			"href": "https://api.example.org/v3/apps/1cb006ee-fb05-47e1-b541-c34179ddc446/features"
+		}
+	},
+	"metadata": {
+		"labels": {},
+		"annotations": {}
+	}
+}


### PR DESCRIPTION
Updating compatibility matrix with SCOSB and OSBAPI versions

Updating default buildpack to empty String. Nulls are not allowed by operations and the only way to enable autodiscovery is by passing and empty list, passing an empty String will trigget that behaviour. Updating tests to document the default buildpack