### PR TITLE
Use status field to check deployment status instead of state

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ onlyShowStandardStreamsOnTestFailure = false
 
 awaitilityVersion = 4.0.2
 blockHoundVersion = 1.0.4.RELEASE
-cfJavaClientVersion = 5.1.0.RELEASE
+cfJavaClientVersion = 5.3.0.RELEASE
 checkstyleVersion = 8.37
 commonsTextVersion = 1.8
 immutablesVersion = 2.8.8

--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/test/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployerUpdateApplicationTest.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/test/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployerUpdateApplicationTest.java
@@ -48,6 +48,8 @@ import org.cloudfoundry.client.v3.builds.Droplet;
 import org.cloudfoundry.client.v3.builds.GetBuildResponse;
 import org.cloudfoundry.client.v3.deployments.CreateDeploymentResponse;
 import org.cloudfoundry.client.v3.deployments.DeploymentState;
+import org.cloudfoundry.client.v3.deployments.DeploymentStatusReason;
+import org.cloudfoundry.client.v3.deployments.DeploymentStatusValue;
 import org.cloudfoundry.client.v3.deployments.DeploymentsV3;
 import org.cloudfoundry.client.v3.deployments.GetDeploymentResponse;
 import org.cloudfoundry.client.v3.packages.BitsData;
@@ -252,6 +254,8 @@ class CloudFoundryAppDeployerUpdateApplicationTest {
 		given(deploymentsV3.get(any()))
 			.willReturn(Mono.just(GetDeploymentResponse.builder()
 				.state(DeploymentState.DEPLOYED)
+				.status(org.cloudfoundry.client.v3.deployments.Status.builder().value(DeploymentStatusValue.FINALIZED).reason(
+					DeploymentStatusReason.DEPLOYED).build())
 				.createdAt("DATETIME")
 				.id("deployment-id")
 				.build()));
@@ -259,6 +263,30 @@ class CloudFoundryAppDeployerUpdateApplicationTest {
 
 	@Test
 	void updateApp() {
+		given(applicationsV2.update(any()))
+			.willReturn(Mono.just(UpdateApplicationResponse.builder()
+				.build()));
+
+		UpdateApplicationRequest request = UpdateApplicationRequest.builder()
+			.name(APP_NAME)
+			.path(APP_PATH)
+			.build();
+
+		StepVerifier.create(appDeployer.update(request))
+			.assertNext(response -> assertThat(response.getName()).isEqualTo(APP_NAME))
+			.verifyComplete();
+	}
+
+	@Test
+	void updateAppWhenDeploymentObjectHasNotState() {
+		given(deploymentsV3.get(any()))
+			.willReturn(Mono.just(GetDeploymentResponse.builder()
+				.status(org.cloudfoundry.client.v3.deployments.Status.builder().value(DeploymentStatusValue.FINALIZED).reason(
+					DeploymentStatusReason.DEPLOYED).build())
+				.createdAt("DATETIME")
+				.id("deployment-id")
+				.build()));
+
 		given(applicationsV2.update(any()))
 			.willReturn(Mono.just(UpdateApplicationResponse.builder()
 				.build()));

--- a/spring-cloud-app-broker-integration-tests/src/test/resources/responses/cloudcontroller/get-deployment-DEPLOYED.json
+++ b/spring-cloud-app-broker-integration-tests/src/test/resources/responses/cloudcontroller/get-deployment-DEPLOYED.json
@@ -1,6 +1,13 @@
 {
 	"guid": "@guid",
 	"state": "DEPLOYED",
+	"status": {
+		"value": "FINALIZED",
+		"reason": "DEPLOYED",
+		"details": {
+			"last_successful_healthcheck": "2018-04-25T22:42:10Z"
+		}
+	},
 	"droplet": {
 		"guid": "44ccfa61-dbcf-4a0d-82fe-f668e9d2a962"
 	},


### PR DESCRIPTION
State field was deprecated in CAPI and starting from CFJC 5.3 marked as nullable, since it won't be sent by CAPI versions 3.91+.

App Broker should use status field instead.