### PR TITLE
Only recreate client if the existing client has different authorities

### DIFF
--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/CloudFoundryAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/CloudFoundryAcceptanceTest.java
@@ -143,8 +143,8 @@ abstract class CloudFoundryAcceptanceTest {
 	@BeforeEach
 	void setUp(TestInfo testInfo, BrokerProperties brokerProperties) {
 		List<String> appBrokerProperties = getAppBrokerProperties(brokerProperties);
-		blockingSubscribe(initializeBroker(appBrokerProperties));
 		blockingSubscribe(initializeUser());
+		blockingSubscribe(initializeBroker(appBrokerProperties));
 	}
 
 	void setUpForBrokerUpdate(BrokerProperties brokerProperties) {
@@ -219,10 +219,7 @@ abstract class CloudFoundryAcceptanceTest {
 			.flatMap(orgId -> cloudFoundryService
 				.getOrCreateSpace(userCloudFoundryService.getOrgName(), userCloudFoundryService.getSpaceName())
 				.map(SpaceSummary::getId)
-				.flatMap(spaceId -> uaaService.createClient(
-						USER_CLIENT_ID,
-						USER_CLIENT_SECRET,
-						USER_CLIENT_AUTHORITIES)
+				.flatMap(spaceId -> uaaService.createClient(USER_CLIENT_ID, USER_CLIENT_SECRET, USER_CLIENT_AUTHORITIES)
 					.then(cloudFoundryService
 						.associateClientWithOrgAndSpace(USER_CLIENT_ID, orgId, spaceId))));
 	}

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/fixtures/cf/CloudFoundryClientConfiguration.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/fixtures/cf/CloudFoundryClientConfiguration.java
@@ -44,6 +44,8 @@ public class CloudFoundryClientConfiguration {
 
 	/**
 	 * The broker client secret
+	 * Please note that acceptance tests setup would not recreate the client if client id or authorities doesn't change.
+	 * Manual environment clean up is needed on existing test environments if secret changes are necessary.
 	 */
 	public static final String APP_BROKER_CLIENT_SECRET = "app-broker-client-secret";
 
@@ -61,6 +63,8 @@ public class CloudFoundryClientConfiguration {
 
 	/**
 	 * The user client secret
+	 * Please note that acceptance tests setup would not recreate the client if client id or authorities doesn't change.
+	 * Manual environment clean up is needed on existing test environments if secret changes are necessary.
 	 */
 	public static final String USER_CLIENT_SECRET = "app-broker-user-client-secret";
 


### PR DESCRIPTION
Previously we recreate client before each test. When multiple tests are running concurrently, if a token is issued for test A but the client was deleted during test B, then the token used for test A would be an 'invalid token' and fail the test. Another error scenario is when test A and test B both trigger client creation at the same time, one of them would error out due to `client already exists`. This fix should avoid most of the risk in terms of client creation