### PR TITLE
Create test orgs and spaces before ATs run

### DIFF
--- a/ci/images/release-ci-image/Dockerfile
+++ b/ci/images/release-ci-image/Dockerfile
@@ -21,3 +21,6 @@ RUN cd /usr/local/bin && curl -L https://github.com/cloudfoundry-incubator/credh
 
 RUN curl -L https://github.com/cloudfoundry/bosh-bootloader/releases/download/v8.4.40/bbl-v8.4.40_linux_x86-64 --output /usr/local/bin/bbl && \
     chmod +x /usr/local/bin/bbl
+
+RUN curl -L https://github.com/cloudfoundry/bosh-cli/releases/download/v6.4.3/bosh-cli-6.4.3-linux-amd64 --output /usr/local/bin/bosh && \
+    chmod +x /usr/local/bin/bosh

--- a/ci/images/release-ci-image/Dockerfile
+++ b/ci/images/release-ci-image/Dockerfile
@@ -1,7 +1,11 @@
 FROM harbor-repo.vmware.com/dockerhub-proxy-cache/library/ubuntu:bionic
 
-RUN apt-get update
-RUN apt-get install --no-install-recommends -y ca-certificates net-tools git curl jq
+RUN apt-get update && apt-get install --no-install-recommends -y ca-certificates net-tools git curl jq gnupg
+
+RUN curl -L https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | apt-key add -
+RUN echo "deb https://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+RUN apt-get update && apt-get install cf-cli
+
 RUN rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME /opt/openjdk
@@ -14,5 +18,6 @@ ADD https://raw.githubusercontent.com/spring-io/concourse-java-scripts/v0.0.3/co
 ADD https://repo.spring.io/libs-release/io/spring/concourse/releasescripts/concourse-release-scripts/0.3.2/concourse-release-scripts-0.3.2.jar /opt/
 
 RUN cd /usr/local/bin && curl -L https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/2.9.0/credhub-linux-2.9.0.tgz | tar xz
+
 RUN curl -L https://github.com/cloudfoundry/bosh-bootloader/releases/download/v8.4.40/bbl-v8.4.40_linux_x86-64 --output /usr/local/bin/bbl && \
     chmod +x /usr/local/bin/bbl

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -65,6 +65,8 @@ jobs:
             action: claim
       - task: acceptance-tests
         file: git-repo/ci/tasks/acceptance-tests.yml
+        vars:
+          release-image-tag: ((release-image-tag))
     on_success:
       in_parallel:
         - *slack-success-notification

--- a/ci/scripts/acceptance-tests.sh
+++ b/ci/scripts/acceptance-tests.sh
@@ -7,6 +7,7 @@ readonly DEFAULT_ORG="${DEFAULT_ORG:?must be set}"
 readonly DEFAULT_SPACE="${DEFAULT_SPACE:?must be set}"
 readonly SKIP_SSL_VALIDATION="${SKIP_SSL_VALIDATION:?must be set}"
 readonly ONLY_SHOW_STANDARD_STREAMS_ON_TEST_FAILURE="${ONLY_SHOW_STANDARD_STREAMS_ON_TEST_FAILURE:-true}"
+readonly DEPLOYMENT_DIRECTORY="$(mktemp -d)"
 
 declare API_HOST
 readonly API_PORT=443
@@ -21,12 +22,28 @@ discover_environment() {
 
   eval "$(bbl print-env --metadata-file "$TOOLSMITH_ENV_INPUT/metadata")"
 
-  API_HOST="$(jq -r .cf.api_url < "$TOOLSMITH_ENV_INPUT/metadata")"
+  API_HOST="$(jq -r .cf.api_url <"$TOOLSMITH_ENV_INPUT/metadata")"
   PASSWORD="$(credhub get -n "/bosh-${env_name}/cf/cf_admin_password" -q)"
   CLIENT_SECRET="$(credhub get -n "/bosh-${env_name}/cf/uaa_admin_client_secret" -q)"
 }
 
-prepare_environment() {
+prepare_cf_deployment() {
+  pushd "$DEPLOYMENT_DIRECTORY" > /dev/null
+
+  bosh --deployment cf manifest > manifest.yml
+
+  cat << EOF > ops.yml
+- type: replace
+  path: /instance_groups/name=diego-cell/instances
+  value: 3
+EOF
+
+  bosh --non-interactive --deployment cf deploy --ops-file ops.yml manifest.yml
+
+  popd > /dev/null
+}
+
+prepare_cf() {
   local test_instances_org
   test_instances_org="$DEFAULT_ORG-instances"
 
@@ -50,9 +67,9 @@ run_tests() {
   export SPRING_CLOUD_APPBROKER_ACCEPTANCETEST_CLOUDFOUNDRY_DEFAULT_SPACE="${DEFAULT_SPACE}"
   export SPRING_CLOUD_APPBROKER_ACCEPTANCETEST_CLOUDFOUNDRY_SKIP_SSL_VALIDATION="${SKIP_SSL_VALIDATION}"
   export TESTS_BROKERAPPPATH=build/libs/spring-cloud-app-broker-acceptance-tests.jar
-  ./gradlew -PacceptanceTests \
-  	-PonlyShowStandardStreamsOnTestFailure="${ONLY_SHOW_STANDARD_STREAMS_ON_TEST_FAILURE}" \
-  	:spring-cloud-app-broker-acceptance-tests:test
+  ./gradlew --console rich -PacceptanceTests \
+    -PonlyShowStandardStreamsOnTestFailure="${ONLY_SHOW_STANDARD_STREAMS_ON_TEST_FAILURE}" \
+    :spring-cloud-app-broker-acceptance-tests:test
 }
 
 main() {
@@ -61,11 +78,12 @@ main() {
   echo "Running tests against $API_HOST"
   echo
 
-  prepare_environment
+  prepare_cf_deployment
+  prepare_cf
 
-  pushd "git-repo" > /dev/null
-    run_tests
-  popd > /dev/null
+  pushd "git-repo" >/dev/null
+  run_tests
+  popd >/dev/null
 }
 
 main

--- a/scripts/clean-env.sh
+++ b/scripts/clean-env.sh
@@ -87,12 +87,12 @@ cf routes
 cf target -o system -s system
 
 cf delete-org -f ${TEST_INSTANCES_ORG}
-cf create-org ${TEST_INSTANCES_ORG} -q runaway
+cf create-org ${TEST_INSTANCES_ORG}
 cf target -o ${TEST_INSTANCES_ORG}
 cf create-space ${TEST_SPACE}
 
 cf delete-org -f ${TEST_ORG}
-cf create-org ${TEST_ORG} -q runaway
+cf create-org ${TEST_ORG}
 cf target -o ${TEST_ORG}
 cf create-space ${TEST_SPACE}
 
@@ -100,3 +100,5 @@ cf target -o ${TEST_ORG} -s ${TEST_SPACE}
 
 cf delete-service-broker test-broker-create-instance-space-per-si -f
 cf delete-service-broker test-broker-create-instance-with-services -f
+cf delete-service-broker test-broker-update-with-new-services -f
+cf delete-service-broker test-broker-update-with-new-services-and-target -f


### PR DESCRIPTION
`runaway` quota should not be required because the default toolsmiths quota is already very generous:

```
➜  spring-cloud-app-broker git:(gareth/toolsmith-env-for-ats) ✗ cf quotas
Getting quotas as admin...
OK

name      total memory   instance memory   routes   service instances   paid plans   app instances   route ports
default   100G           unlimited         1000     unlimited           allowed      unlimited       100
```

I also removed the `credhub login` step because I noticed that the credhub cli is warning that it's not actually necessary given all the credentials have already been set as env vars.