### PR TITLE
Use GH Tokens for pipelines

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -41,6 +41,8 @@ jobs:
           ci-image-tag: ((ci-image-tag))
       - put: artifactory-repo
         params: &artifactory-params
+          signing_key: ((signing-key))
+          signing_passphrase: ((signing-passphrase))
           repo: libs-snapshot-local
           folder: distribution-repository
           build_uri: "${ATC_EXTERNAL_URL}/teams/${BUILD_TEAM_NAME}/pipelines/${BUILD_PIPELINE_NAME}/jobs/${BUILD_JOB_NAME}/builds/${BUILD_NAME}"
@@ -227,7 +229,7 @@ resources:
     type: git
     source:
       uri: ((github-repo))
-      username: ((github-username))
+      username: ((github-token))
       password: ((github-password))
       branch: ((branch))
       ignore_paths: ["ci/images/*"]
@@ -237,7 +239,7 @@ resources:
     type: git
     source:
       uri: ((github-repo))
-      username: ((github-username))
+      username: ((github-token))
       password: ((github-password))
       branch: ((github-username))/staging
 


### PR DESCRIPTION
Initially I was going to reuse the username secret, but that is required later for the branch creation, so we need to have 2 secrets one with the name and the other with the token.

The password is a placeholder required.