### PR TITLE
Scaling vm types

### DIFF
--- a/ci/scripts/acceptance-tests.sh
+++ b/ci/scripts/acceptance-tests.sh
@@ -34,8 +34,14 @@ prepare_cf_deployment() {
 
   cat << EOF > ops.yml
 - type: replace
-  path: /instance_groups/name=diego-cell/instances
-  value: 3
+  path: /instance_groups/name=diego-cell/vm_type
+  value: large
+- type: replace
+  path: /instance_groups/name=router/vm_type
+  value: large
+- type: replace
+  path: /instance_groups/name=api/vm_type
+  value: large
 EOF
 
   bosh --non-interactive --deployment cf deploy --ops-file ops.yml manifest.yml


### PR DESCRIPTION
By default, cf-deployment uses minimal vm type, scaling the main components up vertically
to use large instead.