### PR TITLE
Upgrade to Spring CredHub 2.2.0-RC1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
 		openServiceBrokerVersion = "3.3.0"
 		pmdVersion = "6.29.0"
 		springBootVersion = "2.4.3"
-		springCredhubVersion = "2.2.0-SNAPSHOT"
+		springCredhubVersion = "2.2.0-RC1"
 		springFrameworkVersion = "5.3.4"
 		wiremockVersion = "2.27.2"
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
 		openServiceBrokerVersion = "3.3.0"
 		pmdVersion = "6.29.0"
 		springBootVersion = "2.4.3"
-		springCredhubVersion = "2.1.1.RELEASE"
+		springCredhubVersion = "2.2.0-SNAPSHOT"
 		springFrameworkVersion = "5.3.4"
 		wiremockVersion = "2.27.2"
 	}


### PR DESCRIPTION
Draft PR to verify that Spring CredHub dependency upgrades work with App Broker in acceptance tests. 