### PR TITLE
Update nohttp to ignore daemon logs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -414,7 +414,11 @@ task codeCoverageReport(type: JacocoReport) {
 }
 
 wrapper {
-	gradleVersion = "6.5.1"
+	gradleVersion = "6.8.1"
+}
+
+nohttp {
+	source.exclude "**/gradle/**"
 }
 
 def getDocumentationProjects() {


### PR DESCRIPTION
In order to exclude reading the gradle logs