### PR TITLE
Removing releases repository

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -13,7 +13,6 @@ pluginManagement {
 dependencyResolutionManagement {
 	repositories {
 		mavenCentral()
-		maven { url "https://repo.spring.io/release" }
 		if (version =~ /((-M|-RC)[0-9]+|-SNAPSHOT)$/) {
 			maven { url "https://repo.spring.io/milestone" }
 		}


### PR DESCRIPTION
As per https://spring.io/blog/2022/12/14/notice-of-permissions-changes-to-repo-spring-io-january-2023