### PR TITLE
Adding buildpacks to deployer properties

### DIFF
--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployer.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployer.java
@@ -730,6 +730,10 @@ public class CloudFoundryAppDeployer implements AppDeployer, ResourceLoaderAware
 
 		if (getDockerImage(appResource) == null) {
 			manifest.buildpack(buildpack(deploymentProperties));
+			String buildpacks = buildpacks(deploymentProperties);
+			if (StringUtils.hasText(buildpacks)) {
+				manifest.buildpacks(Arrays.asList(buildpacks.split(",")));
+			}
 		}
 		else {
 			manifest.docker(Docker.builder().image(getDockerImage(appResource)).build());
@@ -1035,6 +1039,11 @@ public class CloudFoundryAppDeployer implements AppDeployer, ResourceLoaderAware
 	private String buildpack(Map<String, String> properties) {
 		return Optional.ofNullable(properties.get(CloudFoundryDeploymentProperties.BUILDPACK_PROPERTY_KEY))
 			.orElse(this.defaultDeploymentProperties.getBuildpack());
+	}
+
+	private String buildpacks(Map<String, String> properties) {
+		return Optional.ofNullable(properties.get(CloudFoundryDeploymentProperties.BUILDPACKS_PROPERTY_KEY))
+			.orElse(this.defaultDeploymentProperties.getBuildpacks());
 	}
 
 	private String javaOpts(Map<String, String> properties) {

--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryDeploymentProperties.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryDeploymentProperties.java
@@ -86,6 +86,11 @@ public class CloudFoundryDeploymentProperties extends DeploymentProperties {
 	protected static final String BUILDPACK_PROPERTY_KEY = "buildpack";
 
 	/**
+	 * Key for storing the buildpacks deployment property
+	 */
+	protected static final String BUILDPACKS_PROPERTY_KEY = "buildpacks";
+
+	/**
 	 * Key for storing JAVA_OPTS deployment property
 	 */
 	protected static final String JAVA_OPTS_PROPERTY_KEY = "javaOpts";
@@ -115,6 +120,11 @@ public class CloudFoundryDeploymentProperties extends DeploymentProperties {
 	 * The buildpack to use for deploying the application.
 	 */
 	private String buildpack = "";
+
+	/**
+	 * The buildpacks to use for deploying the application.
+	 */
+	private String buildpacks = "";
 
 	/**
 	 * The type of health check to perform on deployed application, if not overridden per-app.  Defaults to PORT
@@ -174,6 +184,14 @@ public class CloudFoundryDeploymentProperties extends DeploymentProperties {
 
 	public void setBuildpack(String buildpack) {
 		this.buildpack = buildpack;
+	}
+
+	public String getBuildpacks() {
+		return buildpacks;
+	}
+
+	public void setBuildpacks(String buildpacks) {
+		this.buildpacks = buildpacks;
 	}
 
 	public boolean isEnableRandomAppNamePrefix() {

--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/test/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployerTest.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/test/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployerTest.java
@@ -207,7 +207,7 @@ class CloudFoundryAppDeployerTest {
 			.property(DeploymentProperties.DISK_PROPERTY_KEY, "3G")
 			.property(CloudFoundryDeploymentProperties.HEALTHCHECK_PROPERTY_KEY, "http")
 			.property(CloudFoundryDeploymentProperties.HEALTHCHECK_HTTP_ENDPOINT_PROPERTY_KEY, "/healthcheck")
-			.property(CloudFoundryDeploymentProperties.BUILDPACK_PROPERTY_KEY, "buildpack")
+			.property(CloudFoundryDeploymentProperties.BUILDPACKS_PROPERTY_KEY, "buildpack1,buildpack2")
 			.property(CloudFoundryDeploymentProperties.DOMAINS_PROPERTY, "domain1,domain2")
 			.property(DeploymentProperties.HOST_PROPERTY_KEY, "host")
 			.property(CloudFoundryDeploymentProperties.NO_ROUTE_PROPERTY, "true")
@@ -225,7 +225,7 @@ class CloudFoundryAppDeployerTest {
 			.disk(3072)
 			.healthCheckType(ApplicationHealthCheck.HTTP)
 			.healthCheckHttpEndpoint("/healthcheck")
-			.buildpack("buildpack")
+			.buildpacks("buildpack1", "buildpack2")
 			.domains("domain2", "domain1") // domains is a list so order matters
 			.host("host")
 			.noRoute(true)

--- a/spring-cloud-app-broker-docs/src/docs/asciidoc/service-instances.adoc
+++ b/spring-cloud-app-broker-docs/src/docs/asciidoc/service-instances.adoc
@@ -85,7 +85,11 @@ The following table lists properties that can be set for all or for specific app
 |
 
 |`buildpack`
-|The buildpack to use for deploying the application.
+|The single buildpack to use for deploying the application.
+|
+
+|`buildpacks`
+|Comma separated list of buildpacks to use for deploying the application.
 |
 
 |`domain`


### PR DESCRIPTION
In order to enable multiple buildpacks to be added to the backing application manifest