### PR TITLE
Fix checkstyle nohttp race

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -404,6 +404,7 @@ wrapper {
 }
 
 nohttp {
+	source.exclude "**/build/**"
 	source.exclude "**/gradle/**"
 }
 


### PR DESCRIPTION
Ignore build output in the checkstyle nohttp check. This prevents build output from other parallel tasks from causing the check to fail.