### PR TITLE
Don't use rich Gradle output for ATs

### DIFF
--- a/ci/scripts/acceptance-tests.sh
+++ b/ci/scripts/acceptance-tests.sh
@@ -77,7 +77,7 @@ run_tests() {
   export SPRING_CLOUD_APPBROKER_ACCEPTANCETEST_CLOUDFOUNDRY_DEFAULT_SPACE="${DEFAULT_SPACE}"
   export SPRING_CLOUD_APPBROKER_ACCEPTANCETEST_CLOUDFOUNDRY_SKIP_SSL_VALIDATION="${SKIP_SSL_VALIDATION}"
   export TESTS_BROKERAPPPATH=build/libs/spring-cloud-app-broker-acceptance-tests.jar
-  ./gradlew --console rich -PacceptanceTests \
+  ./gradlew -PacceptanceTests \
     -PonlyShowStandardStreamsOnTestFailure="${ONLY_SHOW_STANDARD_STREAMS_ON_TEST_FAILURE}" \
     :spring-cloud-app-broker-acceptance-tests:test
 }


### PR DESCRIPTION
Because it makes the output in the Concourse UI messy