### PR TITLE
(1.6.x) Remove Spring Boot duplication in configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ buildscript {
 		immutablesVersion = "2.9.3"
 		openServiceBrokerVersion = "3.6.1"
 		pmdVersion = "6.29.0"
-		springBootVersion = "2.7.11"
 		springCredhubVersion = "2.3.0"
 		springFrameworkVersion = "5.3.22"
 		wiremockVersion = "2.27.2"
@@ -34,7 +33,7 @@ buildscript {
 }
 
 plugins {
-	id "io.spring.nohttp" version "0.0.11"
+	id 'io.spring.nohttp'
 	id 'distribution'
 	id 'jacoco'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,11 +1,10 @@
 pluginManagement {
 	plugins {
+		id 'io.spring.nohttp' version "0.0.11"
 		id 'org.springframework.boot' version "2.7.11"
 	}
 	repositories {
-		mavenCentral()
-		maven { url "https://repo.spring.io/release" }
-		maven { url "https://plugins.gradle.org/m2/" }
+		gradlePluginPortal()
 	}
 }
 

--- a/spring-cloud-app-broker-acceptance-tests/build.gradle
+++ b/spring-cloud-app-broker-acceptance-tests/build.gradle
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
+
 plugins {
 	id 'org.springframework.boot'
 }
@@ -21,7 +23,7 @@ plugins {
 description = "Spring Cloud App Broker Acceptance Tests"
 
 dependencies {
-	api platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+	api platform(SpringBootPlugin.BOM_COORDINATES)
 	api project(":spring-cloud-starter-app-broker-cloudfoundry")
 	api "org.springframework.boot:spring-boot-starter-webflux"
 

--- a/spring-cloud-app-broker-autoconfigure/build.gradle
+++ b/spring-cloud-app-broker-autoconfigure/build.gradle
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
+
+plugins {
+	id 'org.springframework.boot' apply false
+}
+
 description = "Spring Cloud App Broker Autoconfiguration"
 
 java {
@@ -23,11 +29,11 @@ java {
 }
 
 dependencies {
-	annotationProcessor platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+	annotationProcessor platform(SpringBootPlugin.BOM_COORDINATES)
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 	annotationProcessor "org.springframework.boot:spring-boot-autoconfigure-processor"
 
-	api platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+	api platform(SpringBootPlugin.BOM_COORDINATES)
 	api project(":spring-cloud-app-broker-core")
 	api project(":spring-cloud-app-broker-deployer")
 	api project(":spring-cloud-app-broker-deployer-cloudfoundry")

--- a/spring-cloud-app-broker-core/build.gradle
+++ b/spring-cloud-app-broker-core/build.gradle
@@ -14,13 +14,19 @@
  * limitations under the License.
  */
 
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
+
+plugins {
+	id 'org.springframework.boot' apply false
+}
+
 description = "Spring Cloud App Broker Core"
 
 dependencies {
 	api project(":spring-cloud-app-broker-deployer")
 	api "org.springframework.cloud:spring-cloud-open-service-broker-core:${openServiceBrokerVersion}"
 
-	api platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+	api platform(SpringBootPlugin.BOM_COORDINATES)
 	api "org.springframework:spring-core"
 	api "org.springframework:spring-context"
 	api "io.projectreactor:reactor-core"

--- a/spring-cloud-app-broker-deployer-cloudfoundry/build.gradle
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/build.gradle
@@ -14,10 +14,16 @@
  * limitations under the License.
  */
 
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
+
+plugins {
+	id 'org.springframework.boot' apply false
+}
+
 description = "Spring Cloud App Broker Deployer Cloud Foundry"
 
 dependencies {
-	api platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+	api platform(SpringBootPlugin.BOM_COORDINATES)
 	api project(":spring-cloud-app-broker-deployer")
 	api "org.cloudfoundry:cloudfoundry-client-reactor:${cfJavaClientVersion}"
 	api "org.cloudfoundry:cloudfoundry-operations:${cfJavaClientVersion}"

--- a/spring-cloud-app-broker-deployer/build.gradle
+++ b/spring-cloud-app-broker-deployer/build.gradle
@@ -14,10 +14,16 @@
  * limitations under the License.
  */
 
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
+
+plugins {
+	id 'org.springframework.boot' apply false
+}
+
 description = "Spring Cloud App Broker Deployer"
 
 dependencies {
-	api platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+	api platform(SpringBootPlugin.BOM_COORDINATES)
 	api "org.springframework:spring-core"
 	api "io.projectreactor:reactor-core"
 

--- a/spring-cloud-app-broker-docs/build.gradle
+++ b/spring-cloud-app-broker-docs/build.gradle
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
+
 plugins {
+	id 'org.springframework.boot' apply false
 	id 'org.asciidoctor.jvm.pdf' version '3.3.2'
 	id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
@@ -26,7 +29,7 @@ configurations {
 }
 
 dependencies {
-	implementation platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+	implementation platform(SpringBootPlugin.BOM_COORDINATES)
 	implementation project(":spring-cloud-app-broker-core")
 	implementation "org.springframework.boot:spring-boot-starter"
 	implementation "org.springframework.boot:spring-boot-starter-data-r2dbc"

--- a/spring-cloud-app-broker-integration-tests/build.gradle
+++ b/spring-cloud-app-broker-integration-tests/build.gradle
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
+
 plugins {
 	id 'org.springframework.boot'
 }
@@ -21,7 +23,7 @@ plugins {
 description = "Spring Cloud App Broker Integration Tests"
 
 dependencies {
-	implementation platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+	implementation platform(SpringBootPlugin.BOM_COORDINATES)
 	implementation project(":spring-cloud-starter-app-broker-cloudfoundry")
 	implementation "org.springframework.boot:spring-boot-starter-webflux"
 

--- a/spring-cloud-app-broker-logging/build.gradle
+++ b/spring-cloud-app-broker-logging/build.gradle
@@ -14,10 +14,16 @@
  * limitations under the License.
  */
 
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
+
+plugins {
+	id 'org.springframework.boot'
+}
+
 description = "Spring Cloud App Broker Logging"
 
 dependencies {
-	api platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+	api platform(SpringBootPlugin.BOM_COORDINATES)
     api "org.springframework.boot:spring-boot-starter-webflux"
     api "org.cloudfoundry:cloudfoundry-client-reactor:${cfJavaClientVersion}"
     api "org.cloudfoundry:cloudfoundry-operations:${cfJavaClientVersion}"

--- a/spring-cloud-app-broker-security-credhub/build.gradle
+++ b/spring-cloud-app-broker-security-credhub/build.gradle
@@ -14,10 +14,16 @@
  * limitations under the License.
  */
 
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
+
+plugins {
+	id 'org.springframework.boot'
+}
+
 description = "Spring Cloud App Broker Security CredHub"
 
 dependencies {
-	api platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+	api platform(SpringBootPlugin.BOM_COORDINATES)
 	api project(":spring-cloud-app-broker-core")
 	api "org.springframework.credhub:spring-credhub-starter:${springCredhubVersion}"
 	api "org.springframework.cloud:spring-cloud-open-service-broker-core:${openServiceBrokerVersion}"


### PR DESCRIPTION
This allows removing `springBootVersion` so that the actual version can be set only once in the boot plugin in 'settings.gradle'. This requires adding the boot plugin to all modules, modules that do not use use 'apply false' to only add the plugin libraries to the build runtime.

This will fix the inconsistency of dependabot updates, because we are getting 2 PRs for each Boot bump, instead of one with the updated version in all places.