### PR TITLE
(1.4.x) Remove spring boot duplication in configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ buildscript {
 		immutablesVersion = "2.9.3"
 		openServiceBrokerVersion = "3.4.2"
 		pmdVersion = "6.29.0"
-		springBootVersion = "2.5.14"
 		springCredhubVersion = "2.2.0"
 		springFrameworkVersion = "5.3.18"
 		wiremockVersion = "2.27.2"
@@ -34,7 +33,7 @@ buildscript {
 }
 
 plugins {
-	id "io.spring.nohttp" version "0.0.11"
+	id 'io.spring.nohttp'
 	id 'distribution'
 	id 'jacoco'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,13 @@
+pluginManagement {
+	plugins {
+		id 'io.spring.nohttp' version "0.0.11"
+		id 'org.springframework.boot' version "2.5.14"
+	}
+	repositories {
+		gradlePluginPortal()
+	}
+}
+
 rootProject.name = "spring-cloud-app-broker"
 
 include "spring-cloud-app-broker-deployer"

--- a/spring-cloud-app-broker-acceptance-tests/build.gradle
+++ b/spring-cloud-app-broker-acceptance-tests/build.gradle
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
+
 plugins {
-	id 'org.springframework.boot' version "2.5.14"
+	id 'org.springframework.boot'
 }
 
 description = "Spring Cloud App Broker Acceptance Tests"
 
 dependencies {
-	api enforcedPlatform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+	api enforcedPlatform(platform(SpringBootPlugin.BOM_COORDINATES))
 	api project(":spring-cloud-starter-app-broker-cloudfoundry")
 	api "org.springframework.boot:spring-boot-starter-webflux"
 

--- a/spring-cloud-app-broker-acceptance-tests/build.gradle
+++ b/spring-cloud-app-broker-acceptance-tests/build.gradle
@@ -23,7 +23,7 @@ plugins {
 description = "Spring Cloud App Broker Acceptance Tests"
 
 dependencies {
-	api enforcedPlatform(platform(SpringBootPlugin.BOM_COORDINATES))
+	api platform(SpringBootPlugin.BOM_COORDINATES)
 	api project(":spring-cloud-starter-app-broker-cloudfoundry")
 	api "org.springframework.boot:spring-boot-starter-webflux"
 

--- a/spring-cloud-app-broker-autoconfigure/build.gradle
+++ b/spring-cloud-app-broker-autoconfigure/build.gradle
@@ -29,11 +29,11 @@ java {
 }
 
 dependencies {
-	annotationProcessor enforcedPlatform(platform(SpringBootPlugin.BOM_COORDINATES))
+	annotationProcessor platform(SpringBootPlugin.BOM_COORDINATES)
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 	annotationProcessor "org.springframework.boot:spring-boot-autoconfigure-processor"
 
-	api enforcedPlatform(platform(SpringBootPlugin.BOM_COORDINATES))
+	api platform(SpringBootPlugin.BOM_COORDINATES)
 	api project(":spring-cloud-app-broker-core")
 	api project(":spring-cloud-app-broker-deployer")
 	api project(":spring-cloud-app-broker-deployer-cloudfoundry")

--- a/spring-cloud-app-broker-autoconfigure/build.gradle
+++ b/spring-cloud-app-broker-autoconfigure/build.gradle
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
+
+plugins {
+	id 'org.springframework.boot' apply false
+}
+
 description = "Spring Cloud App Broker Autoconfiguration"
 
 java {
@@ -23,11 +29,11 @@ java {
 }
 
 dependencies {
-	annotationProcessor enforcedPlatform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+	annotationProcessor enforcedPlatform(platform(SpringBootPlugin.BOM_COORDINATES))
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 	annotationProcessor "org.springframework.boot:spring-boot-autoconfigure-processor"
 
-	api enforcedPlatform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+	api enforcedPlatform(platform(SpringBootPlugin.BOM_COORDINATES))
 	api project(":spring-cloud-app-broker-core")
 	api project(":spring-cloud-app-broker-deployer")
 	api project(":spring-cloud-app-broker-deployer-cloudfoundry")

--- a/spring-cloud-app-broker-core/build.gradle
+++ b/spring-cloud-app-broker-core/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 	api project(":spring-cloud-app-broker-deployer")
 	api "org.springframework.cloud:spring-cloud-open-service-broker-core:${openServiceBrokerVersion}"
 
-	api enforcedPlatform(platform(SpringBootPlugin.BOM_COORDINATES))
+	api platform(SpringBootPlugin.BOM_COORDINATES)
 	api "org.springframework:spring-core"
 	api "org.springframework:spring-context"
 	api "io.projectreactor:reactor-core"

--- a/spring-cloud-app-broker-core/build.gradle
+++ b/spring-cloud-app-broker-core/build.gradle
@@ -14,13 +14,19 @@
  * limitations under the License.
  */
 
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
+
+plugins {
+	id 'org.springframework.boot' apply false
+}
+
 description = "Spring Cloud App Broker Core"
 
 dependencies {
 	api project(":spring-cloud-app-broker-deployer")
 	api "org.springframework.cloud:spring-cloud-open-service-broker-core:${openServiceBrokerVersion}"
 
-	api enforcedPlatform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+	api enforcedPlatform(platform(SpringBootPlugin.BOM_COORDINATES))
 	api "org.springframework:spring-core"
 	api "org.springframework:spring-context"
 	api "io.projectreactor:reactor-core"

--- a/spring-cloud-app-broker-deployer-cloudfoundry/build.gradle
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/build.gradle
@@ -14,10 +14,16 @@
  * limitations under the License.
  */
 
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
+
+plugins {
+	id 'org.springframework.boot' apply false
+}
+
 description = "Spring Cloud App Broker Deployer Cloud Foundry"
 
 dependencies {
-	api enforcedPlatform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+	api enforcedPlatform(platform(SpringBootPlugin.BOM_COORDINATES))
 	api project(":spring-cloud-app-broker-deployer")
 	api "org.cloudfoundry:cloudfoundry-client-reactor:${cfJavaClientVersion}"
 	api "org.cloudfoundry:cloudfoundry-operations:${cfJavaClientVersion}"

--- a/spring-cloud-app-broker-deployer-cloudfoundry/build.gradle
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/build.gradle
@@ -23,7 +23,7 @@ plugins {
 description = "Spring Cloud App Broker Deployer Cloud Foundry"
 
 dependencies {
-	api enforcedPlatform(platform(SpringBootPlugin.BOM_COORDINATES))
+	api platform(SpringBootPlugin.BOM_COORDINATES)
 	api project(":spring-cloud-app-broker-deployer")
 	api "org.cloudfoundry:cloudfoundry-client-reactor:${cfJavaClientVersion}"
 	api "org.cloudfoundry:cloudfoundry-operations:${cfJavaClientVersion}"

--- a/spring-cloud-app-broker-deployer/build.gradle
+++ b/spring-cloud-app-broker-deployer/build.gradle
@@ -23,7 +23,7 @@ plugins {
 description = "Spring Cloud App Broker Deployer"
 
 dependencies {
-	api enforcedPlatform(platform(SpringBootPlugin.BOM_COORDINATES))
+	api platform(SpringBootPlugin.BOM_COORDINATES)
 	api "org.springframework:spring-core"
 	api "io.projectreactor:reactor-core"
 

--- a/spring-cloud-app-broker-deployer/build.gradle
+++ b/spring-cloud-app-broker-deployer/build.gradle
@@ -14,10 +14,16 @@
  * limitations under the License.
  */
 
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
+
+plugins {
+	id 'org.springframework.boot' apply false
+}
+
 description = "Spring Cloud App Broker Deployer"
 
 dependencies {
-	api enforcedPlatform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+	api enforcedPlatform(platform(SpringBootPlugin.BOM_COORDINATES))
 	api "org.springframework:spring-core"
 	api "io.projectreactor:reactor-core"
 

--- a/spring-cloud-app-broker-docs/build.gradle
+++ b/spring-cloud-app-broker-docs/build.gradle
@@ -29,7 +29,7 @@ configurations {
 }
 
 dependencies {
-	implementation enforcedPlatform(platform(SpringBootPlugin.BOM_COORDINATES))
+	implementation platform(SpringBootPlugin.BOM_COORDINATES)
 	implementation project(":spring-cloud-app-broker-core")
 	implementation "org.springframework.boot:spring-boot-starter"
 	implementation "org.springframework.boot:spring-boot-starter-data-r2dbc"

--- a/spring-cloud-app-broker-docs/build.gradle
+++ b/spring-cloud-app-broker-docs/build.gradle
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
+
 plugins {
+	id 'org.springframework.boot' apply false
 	id 'org.asciidoctor.jvm.pdf' version '3.3.2'
 	id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
@@ -26,7 +29,7 @@ configurations {
 }
 
 dependencies {
-	implementation enforcedPlatform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+	implementation enforcedPlatform(platform(SpringBootPlugin.BOM_COORDINATES))
 	implementation project(":spring-cloud-app-broker-core")
 	implementation "org.springframework.boot:spring-boot-starter"
 	implementation "org.springframework.boot:spring-boot-starter-data-r2dbc"

--- a/spring-cloud-app-broker-integration-tests/build.gradle
+++ b/spring-cloud-app-broker-integration-tests/build.gradle
@@ -22,7 +22,7 @@ plugins {
 description = "Spring Cloud App Broker Integration Tests"
 
 dependencies {
-	implementation enforcedPlatform(platform(SpringBootPlugin.BOM_COORDINATES))
+	implementation platform(SpringBootPlugin.BOM_COORDINATES)
 	implementation project(":spring-cloud-starter-app-broker-cloudfoundry")
 	implementation "org.springframework.boot:spring-boot-starter-webflux"
 

--- a/spring-cloud-app-broker-integration-tests/build.gradle
+++ b/spring-cloud-app-broker-integration-tests/build.gradle
@@ -13,15 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
-	id 'org.springframework.boot' version "2.5.14"
+	id 'org.springframework.boot'
 }
 
 description = "Spring Cloud App Broker Integration Tests"
 
 dependencies {
-	implementation enforcedPlatform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+	implementation enforcedPlatform(platform(SpringBootPlugin.BOM_COORDINATES))
 	implementation project(":spring-cloud-starter-app-broker-cloudfoundry")
 	implementation "org.springframework.boot:spring-boot-starter-webflux"
 

--- a/spring-cloud-app-broker-logging/build.gradle
+++ b/spring-cloud-app-broker-logging/build.gradle
@@ -23,7 +23,7 @@ plugins {
 description = "Spring Cloud App Broker Logging"
 
 dependencies {
-	api enforcedPlatform(platform(SpringBootPlugin.BOM_COORDINATES))
+	api platform(SpringBootPlugin.BOM_COORDINATES)
     api "org.springframework.boot:spring-boot-starter-webflux"
     api "org.cloudfoundry:cloudfoundry-client-reactor:${cfJavaClientVersion}"
     api "org.cloudfoundry:cloudfoundry-operations:${cfJavaClientVersion}"

--- a/spring-cloud-app-broker-logging/build.gradle
+++ b/spring-cloud-app-broker-logging/build.gradle
@@ -14,10 +14,16 @@
  * limitations under the License.
  */
 
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
+
+plugins {
+	id 'org.springframework.boot' apply false
+}
+
 description = "Spring Cloud App Broker Logging"
 
 dependencies {
-	api enforcedPlatform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+	api enforcedPlatform(platform(SpringBootPlugin.BOM_COORDINATES))
     api "org.springframework.boot:spring-boot-starter-webflux"
     api "org.cloudfoundry:cloudfoundry-client-reactor:${cfJavaClientVersion}"
     api "org.cloudfoundry:cloudfoundry-operations:${cfJavaClientVersion}"

--- a/spring-cloud-app-broker-security-credhub/build.gradle
+++ b/spring-cloud-app-broker-security-credhub/build.gradle
@@ -14,10 +14,16 @@
  * limitations under the License.
  */
 
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
+
+plugins {
+	id 'org.springframework.boot' apply false
+}
+
 description = "Spring Cloud App Broker Security CredHub"
 
 dependencies {
-	api enforcedPlatform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+	api enforcedPlatform(platform(SpringBootPlugin.BOM_COORDINATES))
 	api project(":spring-cloud-app-broker-core")
 	api "org.springframework.credhub:spring-credhub-starter:${springCredhubVersion}"
 	api "org.springframework.cloud:spring-cloud-open-service-broker-core:${openServiceBrokerVersion}"

--- a/spring-cloud-app-broker-security-credhub/build.gradle
+++ b/spring-cloud-app-broker-security-credhub/build.gradle
@@ -23,7 +23,7 @@ plugins {
 description = "Spring Cloud App Broker Security CredHub"
 
 dependencies {
-	api enforcedPlatform(platform(SpringBootPlugin.BOM_COORDINATES))
+	api platform(SpringBootPlugin.BOM_COORDINATES)
 	api project(":spring-cloud-app-broker-core")
 	api "org.springframework.credhub:spring-credhub-starter:${springCredhubVersion}"
 	api "org.springframework.cloud:spring-cloud-open-service-broker-core:${openServiceBrokerVersion}"


### PR DESCRIPTION
* This allows removing springBootVersion so that the actual version can be set only once in the boot plugin in 'settings.gradle'. This requires adding the boot plugin to all modules, modules that do not use use 'apply false' to only add the plugin libraries to the build runtime.
* Updated use of Gradle `enforcePlatform` with `plaform`. Is there any dependency that is in risk if we allow some boot dependency to be overridden buy another?

This will fix the inconsistency of dependabot updates, because we are getting 2 PRs for each Boot bump, instead of one with the updated version in all places.