### PR TITLE
(2.0.x) Bump Spring Boot to v3.0.8

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
 	plugins {
 		id "io.spring.nohttp" version "0.0.11"
-		id 'org.springframework.boot' version "3.0.6"
+		id 'org.springframework.boot' version "3.0.8"
 		id 'org.asciidoctor.jvm.pdf' version '3.3.2'
 		id 'org.asciidoctor.jvm.convert' version '3.3.2'
 	}


### PR DESCRIPTION
Replaces incorrect dependabot PR https://github.com/spring-cloud/spring-cloud-app-broker/pull/797