### PR TITLE
2.0.x Removing CredHub dependency from buildscript

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ buildscript {
 		commonsTextVersion = "1.10.0"
 		immutablesVersion = "2.9.3"
 		openServiceBrokerVersion = "4.0.0"
-		springCredhubVersion = "3.0.0"
 		springFrameworkVersion = "6.0.0"
 		wiremockVersion = "2.35.0"
 	}


### PR DESCRIPTION
Since we deleted the credhub-security module as part of https://github.com/spring-cloud/spring-cloud-app-broker/commit/135e3496d112aff71e06a0a6a46777bac3f7e7c7, we don't need this dependency in the buildscript anymore