### PR TITLE
(2.1.x) Use Gradle resolutionStrategy to align asciidoctor plugin versions

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,9 +1,16 @@
 pluginManagement {
+	resolutionStrategy {
+		eachPlugin {
+			if (requested.id.namespace?.startsWith('org.asciidoctor.jvm')) {
+				useVersion("4.0.1")
+			}
+		}
+	}
 	plugins {
 		id "io.spring.nohttp" version "0.0.11"
 		id 'org.springframework.boot' version "3.1.5"
-		id 'org.asciidoctor.jvm.pdf' version '3.3.2'
-		id 'org.asciidoctor.jvm.convert' version '3.3.2'
+		id 'org.asciidoctor.jvm.pdf'
+		id 'org.asciidoctor.jvm.convert'
 	}
 	repositories {
 		gradlePluginPortal()

--- a/spring-cloud-app-broker-docs/build.gradle
+++ b/spring-cloud-app-broker-docs/build.gradle
@@ -18,8 +18,8 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
 	id 'org.springframework.boot' apply false
+	id 'org.asciidoctor.jvm.convert'
 	id 'org.asciidoctor.jvm.pdf'
-  id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
 description = "Spring Cloud App Broker Documentation"


### PR DESCRIPTION
* All plugins (convert, pdf, etc) are released together and compatibility between versions is not guaranteed.
So, this PR uses 'resolutionStrategy' to assign the same version to all plugins ensuring they are all aligned
* Bump asciidoctor gradle plugins to 4.0.1