### PR TITLE
Removing stack assertion in ATs

### DIFF
--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/CreateInstanceAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/CreateInstanceAcceptanceTest.java
@@ -70,7 +70,7 @@ class CreateInstanceAcceptanceTest extends CloudFoundryAcceptanceTest {
 		"spring.cloud.appbroker.services[0].apps[1].name=" + APP_CREATE_2,
 		"spring.cloud.appbroker.services[0].apps[1].path=" + BACKING_APP_PATH,
 
-		"spring.cloud.appbroker.deployer.cloudfoundry.properties.stack=cflinuxfs3"
+		"spring.cloud.appbroker.deployer.cloudfoundry.properties.stack=cflinuxfs4"
 	})
 	void deployAppsOnCreateService() {
 		// when a service instance is created
@@ -92,7 +92,7 @@ class CreateInstanceAcceptanceTest extends CloudFoundryAcceptanceTest {
 		// and stack is updated when specified
 		Optional<ApplicationDetail> application1Detail = getApplicationDetail(APP_CREATE_1);
 		assertThat(application1Detail).hasValueSatisfying(app -> {
-			assertThat(app.getStack()).isEqualTo("cflinuxfs3");
+			assertThat(app.getStack()).isEqualTo("cflinuxfs4");
 		});
 
 		// and has the environment variables

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/UpgradeInstanceAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/UpgradeInstanceAcceptanceTest.java
@@ -113,7 +113,7 @@ class UpgradeInstanceAcceptanceTest extends CloudFoundryAcceptanceTest {
 		"spring.cloud.appbroker.services[0].apps[0].environment.parameter3=new-config3",
 		"spring.cloud.appbroker.services[0].apps[0].parameters-transformers[0].name=PropertyMapping",
 		"spring.cloud.appbroker.services[0].apps[0].parameters-transformers[0].args.include=upgrade",
-		"spring.cloud.appbroker.deployer.cloudfoundry.properties.stack=cflinuxfs3"
+		"spring.cloud.appbroker.deployer.cloudfoundry.properties.stack=cflinuxfs4"
 	})
 	void upgradesTheServiceInstanceWithNewBackingServiceAndEnvironmentVariables() {
 		// when the service instance is updated with a new service
@@ -133,7 +133,7 @@ class UpgradeInstanceAcceptanceTest extends CloudFoundryAcceptanceTest {
 		// and stack is updated when specified
 		Optional<ApplicationDetail> application1Detail = getApplicationDetail(APP_NAME);
 		assertThat(application1Detail).hasValueSatisfying(app -> {
-			assertThat(app.getStack()).isEqualTo("cflinuxfs3");
+			assertThat(app.getStack()).isEqualTo("cflinuxfs4");
 		});
 
 		// then the backing application was updated with zero downtime

--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/test/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployerTest.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/test/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployerTest.java
@@ -519,7 +519,7 @@ class CloudFoundryAppDeployerTest {
 				.memoryLimit(100)
 				.requestedState("STARTED")
 				.runningInstances(2)
-				.stack("cflinuxfs3")
+				.stack("cflinuxfs4")
 				.build()));
 
 		given(clientApplications.summary(argThat(request -> appId.equals(request.getApplicationId()))))

--- a/spring-cloud-app-broker-integration-tests/src/test/resources/responses/cloudcontroller/get-v3-app-STARTED.json
+++ b/spring-cloud-app-broker-integration-tests/src/test/resources/responses/cloudcontroller/get-v3-app-STARTED.json
@@ -10,7 +10,7 @@
 			"buildpacks": [
 				"java_buildpack"
 			],
-			"stack": "cflinuxfs3"
+			"stack": "cflinuxfs4"
 		}
 	},
 	"relationships": {


### PR DESCRIPTION
Moving all references from cflinuxfs3 to cflinuxfs4.
Most of the cf deployments don't have any other stack aside from cflinuxfs4, moved the assertions to check on 4.
